### PR TITLE
feat: hide window controls on macOS platform

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rmusic",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rmusic",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "dependencies": {
         "@element-plus/icons-vue": "^2.3.1",
         "@tauri-apps/api": "^2",

--- a/src/components/feature/ImmersiveView/ImmersiveView.vue
+++ b/src/components/feature/ImmersiveView/ImmersiveView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, watch } from "vue";
+import { ref, computed, watch, onMounted } from "vue";
 import { useI18n } from "vue-i18n";
 import {
   VideoPlay,
@@ -42,6 +42,15 @@ const emit = defineEmits(["toggle-play", "previous", "next", "exit"]);
 const artistStore = useArtistStore();
 const onlineStore = useOnlineMusicStore();
 const localStore = useLocalMusicStore();
+const isMacPlatform = ref(false);
+
+onMounted(() => {
+  // 检测 macOS 平台
+  // 优先使用 userAgentData，fallback 到 userAgent
+  const ua = navigator.userAgent;
+  isMacPlatform.value = /Mac|iPhone|iPad|iPod/i.test(ua);
+});
+
 const { isMaximized, minimize, toggleMaximize, close } = useWindowControls({
   onClose: "hide",
 });
@@ -227,7 +236,8 @@ watch(
         <el-button @click="emit('exit')" :icon="Back" circle class="back-btn" />
       </el-tooltip>
 
-      <div class="window-controls">
+      <!-- 非 macOS 平台显示窗口控制按钮 -->
+      <div v-if="!isMacPlatform" class="window-controls">
         <el-tooltip :content="t('header.minimize')" placement="bottom" effect="dark">
           <el-button @click="minimize" :icon="Minus" circle />
         </el-tooltip>

--- a/src/components/layout/HeaderBar/HeaderBar.vue
+++ b/src/components/layout/HeaderBar/HeaderBar.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref, watch } from "vue";
+import { computed, ref, watch, onMounted } from "vue";
 import { useI18n } from "vue-i18n";
 import {
   Close,
@@ -27,8 +27,16 @@ const emit = defineEmits(["search"]);
 const searchKeyword = ref("");
 const showHistoryDropdown = ref(false);
 const searchWrapperRef = ref<HTMLElement | null>(null);
+const isMacPlatform = ref(false);
 /** 失焦后延迟关闭历史面板，避免点击历史项时误关 */
 let blurTimer: ReturnType<typeof setTimeout> | null = null;
+
+onMounted(() => {
+  // 检测 macOS 平台
+  // 优先使用 userAgentData，fallback 到 userAgent
+  const ua = navigator.userAgent;
+  isMacPlatform.value = /Mac|iPhone|iPad|iPod/i.test(ua);
+});
 
 const { isMaximized, minimize, toggleMaximize, close } = useWindowControls({
   onClose: "hide",
@@ -172,7 +180,8 @@ function clearHistory(e: Event) {
     </div>
 
     <div class="header-right">
-      <div class="window-controls">
+      <!-- 非 macOS 平台显示窗口控制按钮 -->
+      <div v-if="!isMacPlatform" class="window-controls">
         <div
           class="header-button window-button"
           :title="t('header.minimize')"


### PR DESCRIPTION
- Detect macOS platform using navigator.userAgent
- Hide minimize/maximize/close buttons on macOS
- Applied to HeaderBar and ImmersiveView components