### PR TITLE
release: v1.3.2 playback, library, and UI improvements

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,11 +4,11 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/icon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Tauri + Vue 3 App</title>
+    <title>Rmusic</title>
   </head>
 
   <body>
     <div id="app"></div>
-    <script type="module" src="/src/main.js"></script>
+    <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rmusic",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rmusic",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "dependencies": {
         "@element-plus/icons-vue": "^2.3.1",
         "@tauri-apps/api": "^2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rmusic",
   "private": true,
-  "version": "1.3.1",
+  "version": "1.3.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1220,6 +1220,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "extended"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af9673d8203fcb076b19dfd17e38b3d4ae9f44959416ea532ce72415a6020365"
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3728,7 +3734,7 @@ dependencies = [
 
 [[package]]
 name = "rmusic"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "hmac",
  "rand 0.8.5",
@@ -4289,9 +4295,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "815c942ae7ee74737bb00f965fa5b5a2ac2ce7b6c01c0cc169bbeaf7abd5f5a9"
 dependencies = [
  "lazy_static",
+ "symphonia-bundle-flac",
  "symphonia-bundle-mp3",
+ "symphonia-codec-pcm",
+ "symphonia-codec-vorbis",
+ "symphonia-core",
+ "symphonia-format-ogg",
+ "symphonia-format-riff",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-bundle-flac"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72e34f34298a7308d4397a6c7fbf5b84c5d491231ce3dd379707ba673ab3bd97"
+dependencies = [
+ "log",
  "symphonia-core",
  "symphonia-metadata",
+ "symphonia-utils-xiph",
 ]
 
 [[package]]
@@ -4304,6 +4327,27 @@ dependencies = [
  "log",
  "symphonia-core",
  "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-codec-pcm"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f395a67057c2ebc5e84d7bb1be71cce1a7ba99f64e0f0f0e303a03f79116f89b"
+dependencies = [
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-codec-vorbis"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a98765fb46a0a6732b007f7e2870c2129b6f78d87db7987e6533c8f164a9f30"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-utils-xiph",
 ]
 
 [[package]]
@@ -4320,6 +4364,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "symphonia-format-ogg"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada3505789516bcf00fc1157c67729eded428b455c27ca370e41f4d785bfa931"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-format-riff"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f7be232f962f937f4b7115cbe62c330929345434c834359425e043bfd15f50"
+dependencies = [
+ "extended",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
 name = "symphonia-metadata"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4329,6 +4397,16 @@ dependencies = [
  "lazy_static",
  "log",
  "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-utils-xiph"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "484472580fa49991afda5f6550ece662237b00c6f562c7d9638d1b086ed010fe"
+dependencies = [
+ "symphonia-core",
+ "symphonia-metadata",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rmusic"
-version = "1.3.1"
+version = "1.3.2"
 description = "A modern, lightweight cross-platform desktop music player built with Tauri 2 and Vue 3. Play local audio files and stream online music through third-party API proxies."
 authors = ["xudong7"]
 edition = "2021"
@@ -26,7 +26,14 @@ serde_json = "1"
 tauri-plugin-dialog = "2"
 tauri-plugin-shell = "2"
 rodio = "0.20.1"
-symphonia = { version = "0.5.4", default-features = false, features = ["mp3"] }
+symphonia = { version = "0.5.4", default-features = false, features = [
+  "mp3",
+  "flac",
+  "ogg",
+  "vorbis",
+  "wav",
+  "pcm",
+] }
 tokio = { version = "1.44.2", features = [
   "fs",
   "io-util",

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -119,10 +119,12 @@ fn ensure_sidecar_with_target_triple(
     let dst = binaries_dir.join(format!("{}-{}{}", base_name, target, ext));
     if src.exists() && (source_changed || !dst.exists()) {
         fs::copy(&src, &dst).map_err(|e| {
-            std::io::Error::new(
-                std::io::ErrorKind::Other,
-                format!("copy {} -> {}: {}", src.display(), dst.display(), e),
-            )
+            std::io::Error::other(format!(
+                "copy {} -> {}: {}",
+                src.display(),
+                dst.display(),
+                e
+            ))
         })?;
     }
     Ok(())

--- a/src-tauri/src/file.rs
+++ b/src-tauri/src/file.rs
@@ -18,13 +18,22 @@ use tauri::Manager;
 use tokio::io::AsyncWriteExt;
 
 const STREAM_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
-const LIBRARY_INDEX_VERSION: u32 = 2;
+const LIBRARY_INDEX_VERSION: u32 = 3;
 
 #[derive(Serialize, Deserialize)]
 struct LibraryIndex {
     version: u32,
     root: String,
     files: Vec<MusicFile>,
+    #[serde(default)]
+    directories: Vec<DirectorySnapshot>,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+struct DirectorySnapshot {
+    relative_path: String,
+    modified_ms: u64,
+    child_directories: Vec<String>,
 }
 
 fn supported_audio_extension(path: &Path) -> Option<String> {
@@ -64,22 +73,35 @@ fn library_index_path(app_handle: &AppHandle, scan_path: &Path) -> Result<PathBu
 }
 
 fn read_library_index(index_path: &Path, scan_path: &Path) -> Vec<MusicFile> {
+    read_library_index_value(index_path, scan_path)
+        .filter(|index| index.version == 2 || index.version == LIBRARY_INDEX_VERSION)
+        .map(|index| index.files)
+        .unwrap_or_default()
+}
+
+fn read_library_index_value(index_path: &Path, scan_path: &Path) -> Option<LibraryIndex> {
     let Ok(bytes) = fs::read(index_path) else {
-        return Vec::new();
+        return None;
     };
     let Ok(index) = serde_json::from_slice::<LibraryIndex>(&bytes) else {
-        return Vec::new();
+        return None;
     };
-    if index.version != LIBRARY_INDEX_VERSION || index.root != scan_path.to_string_lossy() {
-        return Vec::new();
+    if index.root != scan_path.to_string_lossy() {
+        return None;
     }
-    index.files
+    Some(index)
+}
+
+fn read_incremental_library_index(index_path: &Path, scan_path: &Path) -> Option<LibraryIndex> {
+    read_library_index_value(index_path, scan_path)
+        .filter(|index| index.version == LIBRARY_INDEX_VERSION)
 }
 
 fn write_library_index(
     index_path: &Path,
     scan_path: &Path,
     files: &[MusicFile],
+    directories: &[DirectorySnapshot],
 ) -> Result<(), String> {
     if let Some(parent) = index_path.parent() {
         fs::create_dir_all(parent).map_err(|e| format!("create library index dir: {}", e))?;
@@ -88,6 +110,7 @@ fn write_library_index(
         version: LIBRARY_INDEX_VERSION,
         root: scan_path.to_string_lossy().to_string(),
         files: files.to_vec(),
+        directories: directories.to_vec(),
     };
     let bytes =
         serde_json::to_vec(&index).map_err(|e| format!("serialize library index: {}", e))?;
@@ -138,11 +161,11 @@ fn collect_metadata_revision(revision: &MetadataRevision, metadata: &mut AudioMe
     }
 }
 
-fn read_mp3_metadata(path: &Path) -> Option<AudioMetadata> {
+fn read_symphonia_metadata(path: &Path, extension: &str) -> Option<AudioMetadata> {
     let source = File::open(path).ok()?;
     let media_source = MediaSourceStream::new(Box::new(source), Default::default());
     let mut hint = Hint::new();
-    hint.with_extension("mp3");
+    hint.with_extension(extension);
 
     let mut probed = symphonia::default::get_probe()
         .format(
@@ -193,11 +216,7 @@ fn read_duration_ms(path: &Path) -> u64 {
 }
 
 fn read_audio_metadata(path: &Path, extension: &str) -> AudioMetadata {
-    let mut metadata = if extension == "mp3" {
-        read_mp3_metadata(path).unwrap_or_default()
-    } else {
-        AudioMetadata::default()
-    };
+    let mut metadata = read_symphonia_metadata(path, extension).unwrap_or_default();
 
     if metadata.duration_ms == 0 {
         metadata.duration_ms = read_duration_ms(path);
@@ -429,6 +448,7 @@ fn copy_file_to_path(source_path: &Path, target_path: &Path) -> Result<(), Strin
 
 /// recursive scan the directory
 /// and add the files to the list
+#[cfg(test)]
 pub fn scan_directory(
     base_path: &std::path::Path,
     dir_path: &std::path::Path,
@@ -469,29 +489,184 @@ pub fn scan_directory(
     }
 }
 
-/// need to scan the files and abstract the certain file types
-/// filter -> mp3, wav, ogg, flac
-/// if path include a dir, the dir also need to be scanned
-fn scan_files_sync(scan_path: &Path) -> Vec<MusicFile> {
-    let mut music_files = Vec::new();
-    let mut id_counter = 0;
+fn relative_path_string(base_path: &Path, path: &Path) -> Option<String> {
+    let relative = path.strip_prefix(base_path).ok()?;
+    if relative.as_os_str().is_empty() {
+        Some(String::new())
+    } else {
+        relative.to_str().map(ToOwned::to_owned)
+    }
+}
 
+fn parent_relative_path(relative_path: &str) -> String {
+    Path::new(relative_path)
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .and_then(Path::to_str)
+        .unwrap_or("")
+        .to_string()
+}
+
+fn scan_directory_incremental(
+    base_path: &Path,
+    dir_path: &Path,
+    cached_directories: &HashMap<String, DirectorySnapshot>,
+    cached_files_by_parent: &HashMap<String, Vec<MusicFile>>,
+    files: &mut Vec<MusicFile>,
+    directories: &mut Vec<DirectorySnapshot>,
+) -> bool {
+    let Ok(metadata) = fs::symlink_metadata(dir_path) else {
+        return false;
+    };
+    if !metadata.is_dir() || metadata.file_type().is_symlink() {
+        return false;
+    }
+
+    let Some(relative_path) = relative_path_string(base_path, dir_path) else {
+        return false;
+    };
+    let current_modified_ms = metadata
+        .modified()
+        .ok()
+        .and_then(|modified| modified.duration_since(UNIX_EPOCH).ok())
+        .map(|duration| duration.as_millis() as u64)
+        .unwrap_or(0);
+    let cached_directory = cached_directories.get(&relative_path);
+    let can_reuse_listing =
+        cached_directory.is_some_and(|cached| cached.modified_ms == current_modified_ms);
+    let mut child_directories = Vec::new();
+
+    if can_reuse_listing {
+        if let Some(cached_files) = cached_files_by_parent.get(&relative_path) {
+            for cached_file in cached_files {
+                let absolute_path = base_path.join(&cached_file.relative_path);
+                let Ok(file_metadata) = fs::symlink_metadata(&absolute_path) else {
+                    continue;
+                };
+                if !file_metadata.is_file() || file_metadata.file_type().is_symlink() {
+                    continue;
+                }
+                let relative = Path::new(&cached_file.relative_path);
+                if let Some(file) = music_file_from_path(0, &absolute_path, relative) {
+                    files.push(file);
+                }
+            }
+        }
+
+        if let Some(cached) = cached_directory {
+            for child_relative in &cached.child_directories {
+                let child_path = base_path.join(child_relative);
+                if scan_directory_incremental(
+                    base_path,
+                    &child_path,
+                    cached_directories,
+                    cached_files_by_parent,
+                    files,
+                    directories,
+                ) {
+                    child_directories.push(child_relative.clone());
+                }
+            }
+        }
+    } else if let Ok(entries) = read_dir(dir_path) {
+        let mut entries: Vec<_> = entries.flatten().collect();
+        entries.sort_by_key(|entry| entry.path());
+
+        for entry in entries {
+            let path = entry.path();
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            if file_type.is_symlink() {
+                continue;
+            }
+            let is_hidden = path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.starts_with('.'));
+            if is_hidden {
+                continue;
+            }
+
+            if file_type.is_dir() {
+                let Some(child_relative) = relative_path_string(base_path, &path) else {
+                    continue;
+                };
+                if scan_directory_incremental(
+                    base_path,
+                    &path,
+                    cached_directories,
+                    cached_files_by_parent,
+                    files,
+                    directories,
+                ) {
+                    child_directories.push(child_relative);
+                }
+            } else if file_type.is_file() && supported_audio_extension(&path).is_some() {
+                if let Ok(relative) = path.strip_prefix(base_path) {
+                    if let Some(file) = music_file_from_path(0, &path, relative) {
+                        files.push(file);
+                    }
+                }
+            }
+        }
+    }
+
+    directories.push(DirectorySnapshot {
+        relative_path,
+        modified_ms: current_modified_ms,
+        child_directories,
+    });
+    true
+}
+
+fn scan_files_incremental(
+    scan_path: &Path,
+    cached_index: Option<&LibraryIndex>,
+) -> (Vec<MusicFile>, Vec<DirectorySnapshot>) {
+    let cached_directories: HashMap<String, DirectorySnapshot> = cached_index
+        .map(|index| {
+            index
+                .directories
+                .iter()
+                .cloned()
+                .map(|directory| (directory.relative_path.clone(), directory))
+                .collect()
+        })
+        .unwrap_or_default();
+    let mut cached_files_by_parent: HashMap<String, Vec<MusicFile>> = HashMap::new();
+    if let Some(index) = cached_index {
+        for file in &index.files {
+            cached_files_by_parent
+                .entry(parent_relative_path(&file.relative_path))
+                .or_default()
+                .push(file.clone());
+        }
+    }
+
+    let mut music_files = Vec::new();
+    let mut directories = Vec::new();
     if scan_path.is_dir() {
-        scan_directory(scan_path, scan_path, &mut music_files, &mut id_counter);
+        scan_directory_incremental(
+            scan_path,
+            scan_path,
+            &cached_directories,
+            &cached_files_by_parent,
+            &mut music_files,
+            &mut directories,
+        );
         music_files.sort_by(|a, b| a.file_name.cmp(&b.file_name));
         for (index, file) in music_files.iter_mut().enumerate() {
             file.id = index as i32;
         }
     } else if supported_audio_extension(scan_path).is_some() {
         if let Some(file_name) = scan_path.file_name() {
-            let relative = Path::new(file_name);
-            if let Some(file) = music_file_from_path(id_counter, scan_path, relative) {
+            if let Some(file) = music_file_from_path(0, scan_path, Path::new(file_name)) {
                 music_files.push(file);
             }
         }
     }
-
-    music_files
+    (music_files, directories)
 }
 
 #[tauri::command]
@@ -516,10 +691,14 @@ pub async fn scan_files(
     let scan_path = resolve_scan_path(path, default_directory, &app_handle)?;
     let index_path = library_index_path(&app_handle, &scan_path)?;
     tokio::task::spawn_blocking(move || {
-        let cached_files = read_library_index(&index_path, &scan_path);
-        let mut files = scan_files_sync(&scan_path);
+        let cached_index = read_incremental_library_index(&index_path, &scan_path);
+        let cached_files = cached_index
+            .as_ref()
+            .map(|index| index.files.clone())
+            .unwrap_or_default();
+        let (mut files, directories) = scan_files_incremental(&scan_path, cached_index.as_ref());
         enrich_music_files(&scan_path, &mut files, &cached_files);
-        if let Err(error) = write_library_index(&index_path, &scan_path, &files) {
+        if let Err(error) = write_library_index(&index_path, &scan_path, &files, &directories) {
             eprintln!("write library index failed: {}", error);
         }
         files

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,24 +4,19 @@ use file::{
 };
 use music::{
     clear_online_audio_cache, get_online_audio_cache_path, get_online_audio_cache_size,
-    get_playback_state, get_progress, play_track, prefetch_netease_song, seek_to, Music,
-    MusicState,
+    get_playback_state, play_track, prefetch_netease_song, prepare_playback_request, seek_to,
+    Music, MusicState, PlaybackRequestIdState,
 };
 use netease::{
     check_online_service_status, get_artist_top_songs, get_song_cover, get_song_lyric,
     get_song_url, play_netease_song, search_online_mix, search_songs,
 };
 use playlist::{read_playlists, write_playlists};
-use rodio::Sink;
-use service::{
-    restart_online_service, setup_service, sidecar_name_for_current_platform, OnlineServiceProcess,
-};
-use std::sync::Arc;
+use service::{ensure_online_service, restart_online_service, OnlineServiceProcess};
 use tauri::Manager;
 use tauri_plugin_autostart::MacosLauncher;
 use tauri_plugin_window_state::{StateFlags, WindowExt};
 use tokio::sync::broadcast::Sender;
-use tokio::sync::Mutex;
 use tray::{quit_app as quit_app_handle, setup_tray};
 
 mod file;
@@ -31,39 +26,34 @@ mod playlist;
 mod service;
 mod tray;
 
-/// handle playback control events that do not start a new track.
-#[tauri::command]
-fn handle_event(sender: tauri::State<Sender<MusicState>>, event: String) -> Result<(), String> {
-    let event: serde_json::Value =
-        serde_json::from_str(&event).map_err(|e| format!("Parse music event error: {}", e))?;
-    let action = event["action"]
-        .as_str()
-        .ok_or_else(|| "Missing music event action".to_string())?;
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum PlaybackControlAction {
+    Play,
+    Pause,
+    Volume,
+}
 
+/// Handle playback control actions that do not start a new track.
+#[tauri::command]
+fn control_playback(
+    sender: tauri::State<Sender<MusicState>>,
+    action: PlaybackControlAction,
+    volume: Option<f32>,
+) -> Result<(), String> {
     let music_state = match action {
-        "recovery" => MusicState::Recovery,
-        "pause" => MusicState::Pause,
-        "volume" => {
-            let volume = event["volume"]
-                .as_f64()
-                .ok_or_else(|| "Missing volume".to_string())?;
-            MusicState::Volume(volume as f32)
+        PlaybackControlAction::Play => MusicState::Recovery,
+        PlaybackControlAction::Pause => MusicState::Pause,
+        PlaybackControlAction::Volume => {
+            let volume = volume.ok_or_else(|| "Missing volume".to_string())?;
+            MusicState::Volume(volume)
         }
-        _ => return Err(format!("Unknown music event action: {}", action)),
     };
 
     sender
         .send(music_state)
         .map(|_| ())
         .map_err(|e| format!("Send music event error: {}", e))
-}
-
-/// check if the sink is empty
-#[tauri::command]
-async fn is_sink_empty(sink: tauri::State<'_, Arc<Mutex<Sink>>>) -> Result<bool, String> {
-    let sink_clone = Arc::clone(&sink);
-    let sink = sink_clone.lock().await;
-    Ok(sink.empty())
 }
 
 #[tauri::command]
@@ -109,8 +99,7 @@ pub fn run() {
             }
 
             // Get the main window - use "main" as the default window label
-            let window = app
-                .get_webview_window("main")
+            app.get_webview_window("main")
                 .and_then(|w| {
                     // Restore the window state if it exists
                     w.restore_state(StateFlags::all()).ok()?;
@@ -118,20 +107,14 @@ pub fn run() {
                 })
                 .expect("failed to get main window");
 
-            let sidecar_name = sidecar_name_for_current_platform();
-            if let Err(e) = setup_service(app, sidecar_name, window.clone()) {
-                eprintln!("Skip sidecar {} (binary not bundled): {}", sidecar_name, e);
-            }
-
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
             quit_app,
-            is_sink_empty,
-            handle_event,
+            control_playback,
             get_playback_state,
-            get_progress,
             play_track,
+            prepare_playback_request,
             prefetch_netease_song,
             get_online_audio_cache_size,
             get_online_audio_cache_path,
@@ -140,6 +123,7 @@ pub fn run() {
             scan_files,
             load_cached_music_files,
             check_online_service_status,
+            ensure_online_service,
             restart_online_service,
             search_songs,
             search_online_mix,
@@ -161,6 +145,7 @@ pub fn run() {
         .manage(music.sink)
         .manage(music.current_duration_ms)
         .manage(music.current_track_id)
+        .manage(PlaybackRequestIdState::default())
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/src-tauri/src/music.rs
+++ b/src-tauri/src/music.rs
@@ -1,11 +1,13 @@
-use rodio::{Decoder, OutputStream, Sink, Source};
+use rodio::cpal::FromSample;
+use rodio::{Decoder, OutputStream, Sample, Sink, Source};
 use serde::{Deserialize, Serialize};
 use sha1::{Digest, Sha1};
 use std::collections::HashMap;
 use std::fs::{self, File};
-use std::io::{BufReader, ErrorKind};
+use std::io::{self, BufReader, ErrorKind, Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex as StdMutex, OnceLock, Weak};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Condvar, Mutex as StdMutex, OnceLock, Weak};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tauri::{AppHandle, Emitter, Manager};
 use tokio::io::AsyncWriteExt;
@@ -18,15 +20,9 @@ const MAX_ONLINE_AUDIO_CACHE_BYTES: u64 = 1024 * 1024 * 1024;
 const MAX_ONLINE_AUDIO_CACHE_FILES: usize = 200;
 const STREAM_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
 const PLAYBACK_END_POLL_INTERVAL: Duration = Duration::from_millis(250);
+const INITIAL_ONLINE_BUFFER_BYTES: u64 = 512 * 1024;
 static CACHE_DOWNLOAD_LOCKS: OnceLock<StdMutex<HashMap<PathBuf, Weak<Mutex<()>>>>> =
     OnceLock::new();
-
-#[derive(Serialize, Debug)]
-pub struct PlaybackProgress {
-    pub position_ms: u64,
-    pub duration_ms: u64,
-    pub is_ended: bool,
-}
 
 #[derive(Serialize, Debug)]
 pub struct PlaybackState {
@@ -74,6 +70,98 @@ pub struct PlaybackDurationState(pub Arc<Mutex<u64>>);
 
 #[derive(Clone)]
 pub struct PlaybackTrackIdState(pub Arc<Mutex<u64>>);
+
+#[derive(Clone, Default)]
+pub struct PlaybackRequestIdState(pub Arc<AtomicU64>);
+
+#[derive(Default)]
+struct ProgressiveDownloadState {
+    downloaded: u64,
+    total: Option<u64>,
+    complete: bool,
+    error: Option<String>,
+}
+
+type SharedProgressiveDownloadState = Arc<(StdMutex<ProgressiveDownloadState>, Condvar)>;
+
+struct ProgressiveFileReader {
+    file: File,
+    state: SharedProgressiveDownloadState,
+}
+
+struct TempFileCleanup {
+    path: PathBuf,
+    armed: bool,
+}
+
+impl TempFileCleanup {
+    fn new(path: PathBuf) -> Self {
+        Self { path, armed: true }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for TempFileCleanup {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = fs::remove_file(&self.path);
+        }
+    }
+}
+
+impl ProgressiveFileReader {
+    fn open(path: &Path, state: SharedProgressiveDownloadState) -> Result<Self, String> {
+        let file = File::open(path)
+            .map_err(|e| format!("open progressive audio file {}: {}", path.display(), e))?;
+        Ok(Self { file, state })
+    }
+}
+
+impl Read for ProgressiveFileReader {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        loop {
+            let read = self.file.read(buf)?;
+            if read > 0 {
+                return Ok(read);
+            }
+
+            let (lock, signal) = &*self.state;
+            let mut state = lock
+                .lock()
+                .map_err(|_| io::Error::other("progressive download state poisoned"))?;
+            if let Some(error) = &state.error {
+                return Err(io::Error::other(error.clone()));
+            }
+            if state.complete {
+                return Ok(0);
+            }
+            state = signal
+                .wait(state)
+                .map_err(|_| io::Error::other("progressive download wait poisoned"))?;
+            drop(state);
+        }
+    }
+}
+
+impl Seek for ProgressiveFileReader {
+    fn seek(&mut self, position: SeekFrom) -> io::Result<u64> {
+        match position {
+            SeekFrom::End(offset) => {
+                let (lock, _) = &*self.state;
+                let state = lock
+                    .lock()
+                    .map_err(|_| io::Error::other("progressive download state poisoned"))?;
+                let end = state.total.unwrap_or(state.downloaded);
+                let target = (end as i128 + offset as i128).clamp(0, u64::MAX as i128) as u64;
+                self.file.seek(SeekFrom::Start(target))
+            }
+            other => self.file.seek(other),
+        }
+    }
+}
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct MusicFile {
@@ -157,22 +245,44 @@ fn decode_file(path: &Path) -> Result<(Decoder<BufReader<File>>, u64), String> {
     Ok((source, duration_ms))
 }
 
-async fn replace_sink_source(
-    source: Decoder<BufReader<File>>,
+fn decode_progressive_file(
+    path: &Path,
+    state: SharedProgressiveDownloadState,
+) -> Result<(Decoder<BufReader<ProgressiveFileReader>>, u64), String> {
+    let reader = ProgressiveFileReader::open(path, state)?;
+    let source = Decoder::new(BufReader::new(reader))
+        .map_err(|e| format!("decode progressive audio file error: {}", e))?;
+    let duration_ms = source
+        .total_duration()
+        .map(|duration| duration.as_millis() as u64)
+        .unwrap_or(0);
+    Ok((source, duration_ms))
+}
+
+async fn replace_sink_source<S>(
+    source: S,
     duration_ms: u64,
     sink: Arc<Mutex<Sink>>,
     duration: Arc<Mutex<u64>>,
-) {
-    {
-        let mut dur = duration.lock().await;
-        *dur = duration_ms;
-    }
+    request_state: &PlaybackRequestIdState,
+    request_id: u64,
+) -> Result<(), String>
+where
+    S: Source + Send + 'static,
+    f32: FromSample<S::Item>,
+    S::Item: Sample + Send,
+{
     let sink_lock = sink.lock().await;
+    ensure_playback_request_current(Some((request_state, request_id)))?;
+    let mut dur = duration.lock().await;
+    ensure_playback_request_current(Some((request_state, request_id)))?;
+    *dur = duration_ms;
     sink_lock.clear();
     sink_lock.append(source);
     if sink_lock.is_paused() {
         sink_lock.play();
     }
+    Ok(())
 }
 
 fn start_playback_end_monitor(
@@ -272,6 +382,198 @@ fn online_download_lock(cache_path: &Path) -> Result<Arc<Mutex<()>>, String> {
     Ok(lock)
 }
 
+fn set_progressive_download_state(
+    shared: &SharedProgressiveDownloadState,
+    downloaded: u64,
+    total: Option<u64>,
+    complete: bool,
+    error: Option<String>,
+) {
+    let (lock, signal) = &**shared;
+    if let Ok(mut state) = lock.lock() {
+        state.downloaded = downloaded;
+        state.total = total;
+        state.complete = complete;
+        state.error = error;
+        signal.notify_all();
+    }
+}
+
+async fn commit_progressive_cache_file(tmp_path: &Path, cache_path: &Path) -> Result<(), String> {
+    match tokio::fs::hard_link(tmp_path, cache_path).await {
+        Ok(()) => {
+            // An active decoder may still hold the temporary file open on Windows.
+            // The cache hard link is already complete, so leftover .tmp cleanup is best-effort.
+            let _ = tokio::fs::remove_file(tmp_path).await;
+            Ok(())
+        }
+        Err(error) if error.kind() == ErrorKind::AlreadyExists => {
+            let _ = tokio::fs::remove_file(tmp_path).await;
+            Ok(())
+        }
+        Err(error) => Err(format!("commit online cache error: {}", error)),
+    }
+}
+
+async fn progressive_online_file(
+    app_handle: &AppHandle,
+    url: &str,
+    cache_key: &str,
+    request_state: &PlaybackRequestIdState,
+    request_id: u64,
+) -> Result<(PathBuf, SharedProgressiveDownloadState), String> {
+    let cache_path = online_cache_path(app_handle, cache_key)?;
+    if let Ok(metadata) = fs::metadata(&cache_path) {
+        if metadata.len() > 0 {
+            let state = Arc::new((
+                StdMutex::new(ProgressiveDownloadState {
+                    downloaded: metadata.len(),
+                    total: Some(metadata.len()),
+                    complete: true,
+                    error: None,
+                }),
+                Condvar::new(),
+            ));
+            return Ok((cache_path, state));
+        }
+    }
+
+    let download_lock = online_download_lock(&cache_path)?;
+    let download_guard = download_lock.lock_owned().await;
+    ensure_playback_request_current(Some((request_state, request_id)))?;
+    if let Ok(metadata) = fs::metadata(&cache_path) {
+        if metadata.len() > 0 {
+            drop(download_guard);
+            let state = Arc::new((
+                StdMutex::new(ProgressiveDownloadState {
+                    downloaded: metadata.len(),
+                    total: Some(metadata.len()),
+                    complete: true,
+                    error: None,
+                }),
+                Condvar::new(),
+            ));
+            return Ok((cache_path, state));
+        }
+    }
+
+    let client = netease::get_client()?;
+    let mut response = netease::get_response(client, url.to_string()).await?;
+    let total = response.content_length();
+    let tmp_path = unique_temp_path_for(&cache_path);
+    let mut temp_cleanup = TempFileCleanup::new(tmp_path.clone());
+    let mut file = tokio::fs::File::create(&tmp_path)
+        .await
+        .map_err(|e| format!("create online cache file error: {}", e))?;
+    let shared = Arc::new((
+        StdMutex::new(ProgressiveDownloadState {
+            downloaded: 0,
+            total,
+            complete: false,
+            error: None,
+        }),
+        Condvar::new(),
+    ));
+    let buffer_target = total
+        .map(|size| size.min(INITIAL_ONLINE_BUFFER_BYTES))
+        .unwrap_or(INITIAL_ONLINE_BUFFER_BYTES);
+    let mut downloaded = 0u64;
+    let mut reached_end = false;
+
+    while downloaded < buffer_target {
+        ensure_playback_request_current(Some((request_state, request_id)))?;
+        let chunk = tokio::time::timeout(STREAM_IDLE_TIMEOUT, response.chunk())
+            .await
+            .map_err(|_| {
+                format!(
+                    "online audio download stalled for {}s",
+                    STREAM_IDLE_TIMEOUT.as_secs()
+                )
+            })?
+            .map_err(|e| format!("read response data error: {}", e))?;
+        let Some(chunk) = chunk else {
+            reached_end = true;
+            break;
+        };
+        file.write_all(&chunk)
+            .await
+            .map_err(|e| format!("write online cache error: {}", e))?;
+        downloaded = downloaded.saturating_add(chunk.len() as u64);
+        set_progressive_download_state(&shared, downloaded, total, false, None);
+    }
+    file.flush()
+        .await
+        .map_err(|e| format!("flush online cache error: {}", e))?;
+
+    if reached_end {
+        drop(file);
+        commit_progressive_cache_file(&tmp_path, &cache_path).await?;
+        temp_cleanup.disarm();
+        set_progressive_download_state(&shared, downloaded, total, true, None);
+        drop(download_guard);
+        prune_online_audio_cache(app_handle)?;
+        return Ok((cache_path, shared));
+    }
+
+    let background_tmp_path = tmp_path.clone();
+    let background_cache_path = cache_path.clone();
+    let background_shared = Arc::clone(&shared);
+    let background_request_state = Arc::clone(&request_state.0);
+    let background_app_handle = app_handle.clone();
+    temp_cleanup.disarm();
+    tauri::async_runtime::spawn(async move {
+        let result: Result<u64, String> = async {
+            loop {
+                if background_request_state.load(Ordering::SeqCst) != request_id {
+                    return Err("playback request superseded".to_string());
+                }
+                let chunk = tokio::time::timeout(STREAM_IDLE_TIMEOUT, response.chunk())
+                    .await
+                    .map_err(|_| {
+                        format!(
+                            "online audio download stalled for {}s",
+                            STREAM_IDLE_TIMEOUT.as_secs()
+                        )
+                    })?
+                    .map_err(|e| format!("read response data error: {}", e))?;
+                let Some(chunk) = chunk else { break };
+                file.write_all(&chunk)
+                    .await
+                    .map_err(|e| format!("write online cache error: {}", e))?;
+                downloaded = downloaded.saturating_add(chunk.len() as u64);
+                set_progressive_download_state(&background_shared, downloaded, total, false, None);
+            }
+            file.flush()
+                .await
+                .map_err(|e| format!("flush online cache error: {}", e))?;
+            drop(file);
+            commit_progressive_cache_file(&background_tmp_path, &background_cache_path).await?;
+            Ok(downloaded)
+        }
+        .await;
+
+        match result {
+            Ok(final_size) => {
+                set_progressive_download_state(&background_shared, final_size, total, true, None);
+                let _ = prune_online_audio_cache(&background_app_handle);
+            }
+            Err(error) => {
+                let _ = tokio::fs::remove_file(&background_tmp_path).await;
+                set_progressive_download_state(
+                    &background_shared,
+                    downloaded,
+                    total,
+                    true,
+                    Some(error),
+                );
+            }
+        }
+        drop(download_guard);
+    });
+
+    Ok((tmp_path, shared))
+}
+
 fn online_cache_entries(app_handle: &AppHandle) -> Result<Vec<(PathBuf, u64, u64)>, String> {
     let cache_dir = online_cache_dir(app_handle)?;
     let mut entries = Vec::new();
@@ -327,7 +629,9 @@ async fn cached_online_file(
     app_handle: &AppHandle,
     url: &str,
     cache_key: &str,
+    playback_request: Option<(&PlaybackRequestIdState, u64)>,
 ) -> Result<PathBuf, String> {
+    ensure_playback_request_current(playback_request)?;
     let cache_path = online_cache_path(app_handle, cache_key)?;
     if cache_path.exists() {
         return Ok(cache_path);
@@ -335,6 +639,7 @@ async fn cached_online_file(
 
     let download_lock = online_download_lock(&cache_path)?;
     let _download_guard = download_lock.lock().await;
+    ensure_playback_request_current(playback_request)?;
     if cache_path.exists() {
         return Ok(cache_path);
     }
@@ -357,6 +662,7 @@ async fn cached_online_file(
             })?
             .map_err(|e| format!("read response data error: {}", e))?
         {
+            ensure_playback_request_current(playback_request)?;
             file.write_all(&chunk)
                 .await
                 .map_err(|e| format!("write online cache error: {}", e))?;
@@ -388,6 +694,36 @@ async fn cached_online_file(
 
     prune_online_audio_cache(app_handle)?;
     Ok(cache_path)
+}
+
+fn ensure_playback_request_current(
+    playback_request: Option<(&PlaybackRequestIdState, u64)>,
+) -> Result<(), String> {
+    if let Some((state, expected)) = playback_request {
+        if state.0.load(Ordering::SeqCst) != expected {
+            return Err("playback request superseded".to_string());
+        }
+    }
+    Ok(())
+}
+
+fn register_playback_request_id(
+    state: &PlaybackRequestIdState,
+    request_id: u64,
+) -> Result<(), String> {
+    let previous_request_id = state.0.fetch_max(request_id, Ordering::SeqCst);
+    if request_id < previous_request_id {
+        return Err("playback request superseded".to_string());
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub fn prepare_playback_request(
+    request_state: tauri::State<'_, PlaybackRequestIdState>,
+    request_id: u64,
+) -> Result<(), String> {
+    register_playback_request_id(&request_state, request_id)
 }
 
 #[tauri::command]
@@ -425,34 +761,62 @@ pub async fn play_track(
     sink: tauri::State<'_, Arc<Mutex<Sink>>>,
     duration: tauri::State<'_, PlaybackDurationState>,
     track_id: tauri::State<'_, PlaybackTrackIdState>,
+    request_state: tauri::State<'_, PlaybackRequestIdState>,
     source: PlaybackSource,
+    request_id: u64,
 ) -> Result<PlayStartResult, String> {
-    let source_path = match source {
-        PlaybackSource::Local { path } => PathBuf::from(path),
+    register_playback_request_id(&request_state, request_id)?;
+
+    match source {
+        PlaybackSource::Local { path } => {
+            let source_path = PathBuf::from(path);
+            let (decoded_source, duration_ms) = decode_file(&source_path)?;
+            ensure_playback_request_current(Some((&request_state, request_id)))?;
+            replace_sink_source(
+                decoded_source,
+                duration_ms,
+                Arc::clone(&sink),
+                Arc::clone(&duration.0),
+                &request_state,
+                request_id,
+            )
+            .await?;
+        }
         PlaybackSource::Online { url, cache_key } => {
             let resolved_url = if url.trim().is_empty() {
                 netease::get_song_url(cache_key.clone()).await?
             } else {
                 url
             };
-            cached_online_file(&app_handle, &resolved_url, &cache_key).await?
+            let (source_path, download_state) = progressive_online_file(
+                &app_handle,
+                &resolved_url,
+                &cache_key,
+                &request_state,
+                request_id,
+            )
+            .await?;
+            ensure_playback_request_current(Some((&request_state, request_id)))?;
+            let (decoded_source, duration_ms) =
+                decode_progressive_file(&source_path, download_state)?;
+            ensure_playback_request_current(Some((&request_state, request_id)))?;
+            replace_sink_source(
+                decoded_source,
+                duration_ms,
+                Arc::clone(&sink),
+                Arc::clone(&duration.0),
+                &request_state,
+                request_id,
+            )
+            .await?;
         }
-    };
-
-    let (decoded_source, decoded_duration_ms) = decode_file(&source_path)?;
+    }
     let next_track_id = {
         let mut id = track_id.0.lock().await;
         *id = id.saturating_add(1);
         *id
     };
 
-    replace_sink_source(
-        decoded_source,
-        decoded_duration_ms,
-        Arc::clone(&sink),
-        Arc::clone(&duration.0),
-    )
-    .await;
     let duration_ms = *duration.0.lock().await;
     start_playback_end_monitor(
         app_handle,
@@ -481,22 +845,8 @@ pub async fn prefetch_netease_song(app_handle: AppHandle, id: String) -> Result<
     }
 
     let url = netease::get_song_url(id.clone()).await?;
-    cached_online_file(&app_handle, &url, &id).await?;
+    cached_online_file(&app_handle, &url, &id, None).await?;
     Ok(())
-}
-
-#[tauri::command]
-pub async fn get_progress(
-    sink: tauri::State<'_, Arc<Mutex<Sink>>>,
-    duration: tauri::State<'_, PlaybackDurationState>,
-    track_id: tauri::State<'_, PlaybackTrackIdState>,
-) -> Result<PlaybackProgress, String> {
-    let state = get_playback_state(sink, duration, track_id).await?;
-    Ok(PlaybackProgress {
-        position_ms: state.position_ms,
-        duration_ms: state.duration_ms,
-        is_ended: state.is_ended,
-    })
 }
 
 #[tauri::command]

--- a/src-tauri/src/netease.rs
+++ b/src-tauri/src/netease.rs
@@ -1,4 +1,3 @@
-use reqwest;
 use serde::{Deserialize, Serialize};
 use std::sync::OnceLock;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};

--- a/src-tauri/src/service.rs
+++ b/src-tauri/src/service.rs
@@ -30,13 +30,14 @@ pub fn sidecar_name_for_current_platform() -> &'static str {
 }
 
 /// set up the service for the sidecar
-pub fn setup_service(
-    app: &tauri::App,
-    service_name: &str,
-    window: tauri::webview::WebviewWindow,
+#[tauri::command]
+pub fn ensure_online_service(
+    app_handle: tauri::AppHandle,
+    process: tauri::State<'_, OnlineServiceProcess>,
 ) -> Result<(), String> {
-    let process = app.state::<OnlineServiceProcess>();
-    spawn_service(app.handle(), service_name, Some(window), process.inner())
+    let service_name = sidecar_name_for_current_platform();
+    let window = app_handle.get_webview_window("main");
+    spawn_service(&app_handle, service_name, window, process.inner())
 }
 
 fn spawn_service(

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -38,19 +38,19 @@ pub fn setup_tray(app: &mut App) -> Result<(), Box<dyn std::error::Error>> {
     let mut tray_builder = TrayIconBuilder::new()
         .menu(&menu)
         .show_menu_on_left_click(true)
-        .on_tray_icon_event(|tray, event| match event {
-            TrayIconEvent::Click {
+        .on_tray_icon_event(|tray, event| {
+            if let TrayIconEvent::Click {
                 button: MouseButton::Left,
                 button_state: MouseButtonState::Up,
                 ..
-            } => {
+            } = event
+            {
                 let app = tray.app_handle();
                 if let Some(window) = app.get_webview_window("main") {
                     let _ = window.show();
                     let _ = window.set_focus();
                 }
             }
-            _ => {}
         })
         .on_menu_event(|app, event| match event.id.as_ref() {
             "play" => {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "rmusic",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "identifier": "com.rmusic.app",
   "build": {
     "beforeDevCommand": "npm run dev",
@@ -16,12 +16,11 @@
         "title": "rmusic",
         "width": 1200,
         "height": 1000,
-        "minWidth": 900,
+        "minWidth": 760,
         "minHeight": 640,
         "decorations": false,
         "center": true,
-        "shadow": true,
-        "devtools": true
+        "shadow": true
       }
     ],
     "security": {

--- a/src-tauri/tauri.macos.conf.json
+++ b/src-tauri/tauri.macos.conf.json
@@ -6,7 +6,7 @@
         "title": "rmusic",
         "width": 1200,
         "height": 1000,
-        "minWidth": 900,
+        "minWidth": 760,
         "minHeight": 640,
         "decorations": true,
         "titleBarStyle": "Overlay",
@@ -16,8 +16,7 @@
           "y": 14
         },
         "center": true,
-        "shadow": true,
-        "devtools": true
+        "shadow": true
       }
     ]
   },

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,12 @@
 <script setup lang="ts">
-import { onMounted, onUnmounted, computed } from "vue";
+import {
+  onMounted,
+  onUnmounted,
+  computed,
+  nextTick,
+  watch,
+  type WatchStopHandle,
+} from "vue";
 import { useRoute, useRouter } from "vue-router";
 import { useI18n } from "vue-i18n";
 import zhCn from "element-plus/es/locale/lang/zh-cn";
@@ -8,6 +15,7 @@ import { ElConfigProvider } from "element-plus";
 import HeaderBar from "./components/layout/HeaderBar/HeaderBar.vue";
 import Sidebar from "./components/layout/Sidebar/Sidebar.vue";
 import PlayerBar from "./components/feature/PlayerBar/PlayerBar.vue";
+import PlaybackQueue from "./components/feature/PlaybackQueue/PlaybackQueue.vue";
 import ImmersiveView from "./components/feature/ImmersiveView/ImmersiveView.vue";
 import type { SearchScope } from "./types/model";
 import { useAppKeyboardShortcuts } from "./composables/useAppKeyboardShortcuts";
@@ -40,7 +48,7 @@ const playlistStore = usePlaylistStore();
 const route = useRoute();
 const router = useRouter();
 let isQuitting = false;
-let onlineServiceStartTimer: number | null = null;
+let stopOnlineScopeWatch: WatchStopHandle | null = null;
 
 const searchScope = computed<SearchScope | null>(() => {
   if (route.name === "LocalMusic") return "local";
@@ -50,7 +58,7 @@ const searchScope = computed<SearchScope | null>(() => {
 });
 
 const windowSizeConstraints = useWindowSizeConstraints({
-  minWidth: 900,
+  minWidth: 760,
   minHeight: 640,
 });
 const keyboardShortcuts = useAppKeyboardShortcuts({
@@ -88,6 +96,7 @@ async function handleSearch(keyword: string, scope: SearchScope) {
   }
 
   if (kw) {
+    await onlineServiceStore.ensureStarted();
     await onlineStore.searchOnlineMusic(kw);
   } else {
     onlineStore.resetResults();
@@ -96,6 +105,12 @@ async function handleSearch(keyword: string, scope: SearchScope) {
 
 function flushPlaylistSave() {
   void playlistStore.flushSave();
+}
+
+async function closePlaybackQueue() {
+  viewStore.closePlaybackQueue();
+  await nextTick();
+  document.querySelector<HTMLButtonElement>(".queue-btn")?.focus();
 }
 
 async function quitAfterFlush() {
@@ -131,19 +146,21 @@ onMounted(() => {
     runInitTask("tray events", () => trayEvents.start()),
   ]);
 
-  onlineServiceStartTimer = window.setTimeout(() => {
-    onlineServiceStartTimer = null;
-    onlineServiceStore.start();
-  }, 250);
+  stopOnlineScopeWatch = watch(
+    searchScope,
+    (scope) => {
+      if (scope === "online") onlineServiceStore.start();
+      else onlineServiceStore.stop();
+    },
+    { immediate: true }
+  );
 });
 
 onUnmounted(() => {
   keyboardShortcuts.stop();
   themeSync.stop();
-  if (onlineServiceStartTimer !== null) {
-    clearTimeout(onlineServiceStartTimer);
-    onlineServiceStartTimer = null;
-  }
+  stopOnlineScopeWatch?.();
+  stopOnlineScopeWatch = null;
   onlineServiceStore.stop();
   trayEvents.stop();
   playerStore.stopPlayTimeTracking();
@@ -168,10 +185,19 @@ onUnmounted(() => {
           <router-view />
         </div>
       </div>
+      <PlaybackQueue
+        v-if="viewStore.showPlaybackQueue"
+        :items="playerStore.playbackQueueItems"
+        :title="playerStore.playbackQueueTitle"
+        :is-playing="playerStore.isPlaying"
+        @close="closePlaybackQueue"
+        @play="playerStore.playQueueItem"
+      />
       <PlayerBar
         :currentMusic="playerStore.currentMusic"
         :currentOnlineSong="playerStore.currentOnlineSong"
         :isPlaying="playerStore.isPlaying"
+        :playbackPhase="playerStore.playbackPhase"
         :playMode="playerStore.playMode"
         :volume="playerStore.volume"
         :currentPlayTime="playerStore.currentPlayTime"
@@ -181,6 +207,7 @@ onUnmounted(() => {
         @previous="playerStore.playNextOrPreviousMusic(playerStore.getPlayStep(-1))"
         @next="playerStore.playNextOrPreviousMusic(playerStore.getPlayStep(1))"
         @toggle-play-mode="playerStore.togglePlayMode"
+        @toggle-queue="viewStore.togglePlaybackQueue"
         @show-immersive="playerStore.showImmersive"
         @seek="playerStore.seekToPosition"
       />

--- a/src/api/commands/music.ts
+++ b/src/api/commands/music.ts
@@ -6,8 +6,9 @@ export async function handleEvent(
   action: HandleEventAction,
   payload: Record<string, unknown>
 ) {
-  return await invokeCommand("handle_event", {
-    event: JSON.stringify({ action, ...payload }),
+  return await invokeCommand("control_playback", {
+    action: action === "recovery" ? "play" : action,
+    volume: typeof payload.volume === "number" ? payload.volume : null,
   });
 }
 
@@ -20,8 +21,15 @@ export async function playNeteaseSong(args: {
   return await invokeCommand("play_netease_song", args);
 }
 
-export async function playTrack(source: PlaybackSource): Promise<PlayStartResult> {
-  return await invokeCommand("play_track", { source });
+export async function playTrack(
+  source: PlaybackSource,
+  requestId: number
+): Promise<PlayStartResult> {
+  return await invokeCommand("play_track", { source, requestId });
+}
+
+export async function preparePlaybackRequest(requestId: number): Promise<void> {
+  await invokeCommand("prepare_playback_request", { requestId });
 }
 
 export async function prefetchNeteaseSong(id: string): Promise<void> {
@@ -49,17 +57,10 @@ export async function downloadMusic(args: {
   return await invokeCommand("download_music", args);
 }
 
-export async function isSinkEmpty(): Promise<boolean> {
-  return await invokeCommand("is_sink_empty");
-}
-
-export interface PlaybackProgress {
+export interface PlaybackState {
   position_ms: number;
   duration_ms: number;
   is_ended: boolean;
-}
-
-export interface PlaybackState extends PlaybackProgress {
   is_paused: boolean;
   has_track: boolean;
   track_id: number;
@@ -68,10 +69,6 @@ export interface PlaybackState extends PlaybackProgress {
 export interface SeekResult {
   success: boolean;
   should_play_next: boolean;
-}
-
-export async function getProgress(): Promise<PlaybackProgress> {
-  return await invokeCommand("get_progress");
 }
 
 export async function getPlaybackState(): Promise<PlaybackState> {

--- a/src/api/commands/netease.ts
+++ b/src/api/commands/netease.ts
@@ -30,6 +30,10 @@ export async function checkOnlineServiceStatus(): Promise<OnlineServiceStatus> {
   return await invokeCommand("check_online_service_status");
 }
 
+export async function ensureOnlineService(): Promise<void> {
+  return await invokeCommand("ensure_online_service");
+}
+
 export async function restartOnlineService(): Promise<void> {
   return await invokeCommand("restart_online_service");
 }

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -32,13 +32,18 @@ export interface TauriCommandParamsMap {
   quit_app: void;
   scan_files: { path: string | null; defaultDirectory: string | null };
   load_cached_music_files: { path: string | null; defaultDirectory: string | null };
-  handle_event: { event: string };
-  play_track: { source: PlaybackSource };
+  control_playback: {
+    action: "play" | "pause" | "volume";
+    volume: number | null;
+  };
+  play_track: { source: PlaybackSource; requestId: number };
+  prepare_playback_request: { requestId: number };
   prefetch_netease_song: { id: string };
   get_online_audio_cache_size: void;
   get_online_audio_cache_path: void;
   clear_online_audio_cache: void;
   check_online_service_status: void;
+  ensure_online_service: void;
   restart_online_service: void;
   play_netease_song: { id: string; name: string; artist: string; picUrl?: string };
   download_music: {
@@ -59,12 +64,10 @@ export interface TauriCommandParamsMap {
   get_song_lyric: { id: string };
   load_local_cover_path: { fileName: string; defaultDirectory: string | null };
   load_local_lyric: { fileName: string; defaultDirectory: string | null };
-  is_sink_empty: void;
   get_playback_state: void;
   import_music: { files: string[]; defaultDirectory: string | null };
   read_playlists: void;
   write_playlists: { playlists: Playlist[] };
-  get_progress: void;
   seek_to: { positionMs: number };
 }
 
@@ -72,13 +75,15 @@ export interface TauriCommandResultMap {
   quit_app: void;
   scan_files: MusicFile[];
   load_cached_music_files: MusicFile[];
-  handle_event: void;
+  control_playback: void;
   play_track: PlayStartResult;
+  prepare_playback_request: void;
   prefetch_netease_song: void;
   get_online_audio_cache_size: number;
   get_online_audio_cache_path: string;
   clear_online_audio_cache: void;
   check_online_service_status: OnlineServiceStatus;
+  ensure_online_service: void;
   restart_online_service: void;
   play_netease_song: PlaySongResult;
   download_music: string;
@@ -88,12 +93,10 @@ export interface TauriCommandResultMap {
   get_song_lyric: string;
   load_local_cover_path: string | null;
   load_local_lyric: string;
-  is_sink_empty: boolean;
   get_playback_state: PlaybackStateResult;
   import_music: string;
   read_playlists: Playlist[];
   write_playlists: void;
-  get_progress: PlaybackProgressResult;
   seek_to: SeekResult;
 }
 

--- a/src/assets/styles/themes.css
+++ b/src/assets/styles/themes.css
@@ -12,6 +12,17 @@ body {
   overflow: hidden;
 }
 
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+
 html {
   overflow: hidden;
 }
@@ -34,8 +45,8 @@ html {
   --app-content-padding-compact: 16px;
 
   /* 页面骨架 */
-  --app-page-max-width: 1060px;
-  --app-page-wide-max-width: 1180px;
+  --app-page-max-width: 1280px;
+  --app-page-wide-max-width: 1440px;
   --app-page-header-height: 44px;
   --app-page-header-gap: 16px;
   --app-page-title-size: 18px;
@@ -78,8 +89,8 @@ html {
   --app-track-row-gap: 12px;
   --app-track-row-padding-x: 10px;
   --app-track-row-padding-y: 8px;
-  --app-list-reading-width: 860px;
-  --app-online-list-width: 980px;
+  --app-list-reading-width: 1180px;
+  --app-online-list-width: 1280px;
 
   /* 按钮与控件：macOS / Apple Music 风格 */
   --app-button-height: 32px;

--- a/src/components/feature/ImmersiveView/ImmersiveView.css
+++ b/src/components/feature/ImmersiveView/ImmersiveView.css
@@ -34,6 +34,13 @@
   user-select: none;
 }
 
+@media (prefers-reduced-motion: reduce) {
+  .background-cover {
+    filter: none !important;
+    opacity: 0.58;
+  }
+}
+
 .immersive-view.uses-dark-foreground {
   --immersive-control-surface: rgba(245, 248, 250, 0.22);
   --immersive-control-border: rgba(18, 31, 40, 0.22);
@@ -53,24 +60,21 @@
   width: calc(100% + 80px);
   height: calc(100% + 80px);
   z-index: 0;
-  background-size: cover;
-  background-position: center;
+  object-fit: cover;
   opacity: 1;
   filter: saturate(0.82) contrast(1.05);
   transform: scale(1.06);
-  transition:
-    background-image 0.6s ease,
-    opacity 0.3s ease;
+  pointer-events: none;
+  animation: immersive-background-enter 240ms ease-out both;
 }
 
-.background-cover::before {
-  content: "";
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background: rgba(5, 7, 9, 0.08);
+@keyframes immersive-background-enter {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }
 
 /* 遮罩层 */
@@ -262,7 +266,18 @@
 }
 
 .song-artist .artist-part.artist-link {
+  padding: 0;
+  border: 0;
+  color: inherit;
+  background: transparent;
+  font: inherit;
   cursor: pointer;
+}
+
+.song-artist .artist-part.artist-link:focus-visible {
+  border-radius: 3px;
+  outline: 2px solid currentColor;
+  outline-offset: 3px;
 }
 
 .song-artist .artist-part.artist-link:hover {

--- a/src/components/feature/ImmersiveView/ImmersiveView.vue
+++ b/src/components/feature/ImmersiveView/ImmersiveView.vue
@@ -105,19 +105,6 @@ const { artistNames, canNavigateArtist, navigateArtistByName } = useArtistNaviga
   onlineArtists: () => onlineStore.onlineArtists,
 });
 
-// 用于背景的模糊封面样式
-const backgroundStyle = computed(() => {
-  if (currentCoverUrl.value) {
-    return {
-      backgroundImage: `url(${currentCoverUrl.value})`,
-      backgroundSize: "cover",
-      backgroundPosition: "center",
-      backgroundRepeat: "no-repeat",
-    };
-  }
-  return {};
-});
-
 // 背景滤镜样式
 const backgroundFilterStyle = computed(() => {
   return `blur(46px) saturate(1.36) contrast(1.04) brightness(${imageAnalysisState.value.brightness})`;
@@ -173,11 +160,15 @@ const overlayStyle = computed(() => {
       'uses-dark-foreground': usesDarkForeground,
     }"
   >
-    <div
+    <img
       v-if="currentCoverUrl"
+      :key="currentCoverUrl"
+      :src="currentCoverUrl"
       class="background-cover"
-      :style="[backgroundStyle, { filter: backgroundFilterStyle }]"
-    ></div>
+      :style="{ filter: backgroundFilterStyle }"
+      alt=""
+      aria-hidden="true"
+    />
     <div class="overlay" :style="overlayStyle"></div>
     <div
       class="immersive-titlebar-drag-region"
@@ -220,6 +211,7 @@ const overlayStyle = computed(() => {
         <div class="cover-container">
           <img
             v-if="currentCoverUrl"
+            :key="currentCoverUrl"
             :src="currentCoverUrl"
             class="song-cover"
             alt="封面"
@@ -238,14 +230,16 @@ const overlayStyle = computed(() => {
             >
               <template v-if="artistNames.length">
                 <template v-for="(a, idx) in artistNames" :key="a + idx">
-                  <span
+                  <component
+                    :is="canNavigateArtist ? 'button' : 'span'"
+                    :type="canNavigateArtist ? 'button' : undefined"
                     class="artist-part"
                     :class="{ 'artist-link': canNavigateArtist }"
                     @click.stop="navigateArtistByName(a)"
-                    :title="`${a}（点击查看）`"
+                    :title="canNavigateArtist ? t('artist.open', { name: a }) : a"
                   >
                     {{ a }}
-                  </span>
+                  </component>
                   <span v-if="idx < artistNames.length - 1" class="artist-sep">, </span>
                 </template>
               </template>

--- a/src/components/feature/MusicList/MusicList.vue
+++ b/src/components/feature/MusicList/MusicList.vue
@@ -101,12 +101,14 @@ const props = withDefaults(
     currentMusic: MusicFile | null;
     isPlaying: boolean;
     loading?: boolean;
+    refreshing?: boolean;
     showImportButton?: boolean;
     getDefaultDirectory?: () => string | null;
   }>(),
   {
     showImportButton: false,
     loading: false,
+    refreshing: false,
     getDefaultDirectory: () => null,
   }
 );
@@ -184,7 +186,10 @@ function scheduleVisibleCovers(items: TrackRowModel[]) {
 
 <template>
   <PageLayout class="music-list-container">
-    <PageHeader :title="t('musicList.title')">
+    <PageHeader
+      :title="t('musicList.title')"
+      :subtitle="refreshing && musicFiles.length ? t('musicList.updating') : undefined"
+    >
       <template #actions>
         <template v-if="selectionMode">
           <span class="select-actions">

--- a/src/components/feature/OnlineMusicList/OnlineMusicList.vue
+++ b/src/components/feature/OnlineMusicList/OnlineMusicList.vue
@@ -32,7 +32,6 @@ const props = withDefaults(
 
 const emit = defineEmits([
   "play",
-  "prefetch",
   "toggle-current",
   "download",
   "load-more",
@@ -85,7 +84,6 @@ function handleAddToPlaylist(command: string, row: SongInfo) {
       :loading="loading"
       width="online"
       @activate="emit('play', onlineSongs[$event.sourceIndex])"
-      @intent="emit('prefetch', onlineSongs[$event.sourceIndex])"
       @toggle-current="emit('toggle-current')"
       @near-end="requestLoadMore"
     >

--- a/src/components/feature/PlaybackQueue/PlaybackQueue.vue
+++ b/src/components/feature/PlaybackQueue/PlaybackQueue.vue
@@ -1,0 +1,302 @@
+<script setup lang="ts">
+import { computed, nextTick, onMounted, ref } from "vue";
+import { Close, Headset, VideoPause, VideoPlay } from "@element-plus/icons-vue";
+import { useI18n } from "vue-i18n";
+import type { PlaybackQueueItem } from "@/types/model";
+
+const { t } = useI18n();
+const props = defineProps<{
+  items: PlaybackQueueItem[];
+  title: string;
+  isPlaying: boolean;
+}>();
+const emit = defineEmits<{
+  close: [];
+  play: [index: number];
+}>();
+
+const panelRef = ref<HTMLElement | null>(null);
+const currentPosition = computed(() => {
+  const index = props.items.findIndex((item) => item.isCurrent);
+  return index >= 0 ? index + 1 : 0;
+});
+
+onMounted(async () => {
+  await nextTick();
+  panelRef.value?.focus();
+  panelRef.value?.querySelector<HTMLElement>(".is-current")?.scrollIntoView({
+    block: "center",
+  });
+});
+
+function handlePanelKeydown(event: KeyboardEvent) {
+  if (event.key === "Escape") {
+    emit("close");
+    return;
+  }
+  if (event.key !== "Tab" || !panelRef.value) return;
+  const focusable = Array.from(
+    panelRef.value.querySelectorAll<HTMLElement>(
+      'button:not(:disabled), [href], [tabindex]:not([tabindex="-1"])'
+    )
+  );
+  if (!focusable.length) return;
+  const first = focusable[0];
+  const last = focusable[focusable.length - 1];
+  if (event.shiftKey && document.activeElement === first) {
+    event.preventDefault();
+    last.focus();
+  } else if (!event.shiftKey && document.activeElement === last) {
+    event.preventDefault();
+    first.focus();
+  }
+}
+</script>
+
+<template>
+  <div class="queue-layer" @click.self="emit('close')">
+    <aside
+      ref="panelRef"
+      class="queue-panel"
+      tabindex="-1"
+      role="dialog"
+      aria-modal="true"
+      :aria-label="t('playerBar.queue')"
+      @keydown="handlePanelKeydown"
+    >
+      <header class="queue-header">
+        <div class="queue-heading">
+          <h2>{{ t("playerBar.queue") }}</h2>
+          <p>
+            {{ title || t("playerBar.currentQueue") }}
+            <span v-if="items.length">· {{ currentPosition }}/{{ items.length }}</span>
+          </p>
+        </div>
+        <button
+          type="button"
+          class="queue-close app-header-icon-button"
+          :aria-label="t('common.close')"
+          @click="emit('close')"
+        >
+          <el-icon><Close /></el-icon>
+        </button>
+      </header>
+
+      <div v-if="items.length" class="queue-list">
+        <button
+          v-for="item in items"
+          :key="item.key"
+          type="button"
+          class="queue-item"
+          :class="{ 'is-current': item.isCurrent }"
+          :disabled="item.disabled"
+          :aria-current="item.isCurrent ? 'true' : undefined"
+          @click="emit('play', item.sourceIndex)"
+        >
+          <span class="queue-item-index">
+            <el-icon v-if="item.isCurrent">
+              <VideoPause v-if="isPlaying" />
+              <VideoPlay v-else />
+            </el-icon>
+            <span v-else>{{ item.sourceIndex + 1 }}</span>
+          </span>
+          <span class="queue-item-main">
+            <strong>{{ item.title }}</strong>
+            <span>{{ item.artist }}</span>
+          </span>
+          <span class="queue-item-source">
+            {{ t(item.source === "local" ? "common.localMusic" : "onlineMusic.title") }}
+          </span>
+        </button>
+      </div>
+
+      <div v-else class="queue-empty">
+        <el-icon><Headset /></el-icon>
+        <p>{{ t("playerBar.queueEmpty") }}</p>
+      </div>
+    </aside>
+  </div>
+</template>
+
+<style scoped>
+.queue-layer {
+  position: fixed;
+  inset: var(--app-header-height) 0 var(--app-player-height) 0;
+  z-index: 180;
+  display: flex;
+  justify-content: flex-end;
+  background: rgba(15, 23, 42, 0.14);
+  backdrop-filter: blur(2px);
+}
+
+.queue-panel {
+  width: min(390px, calc(100vw - 32px));
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  color: var(--el-text-color-primary);
+  background: color-mix(in srgb, var(--app-card-bg) 94%, transparent);
+  border-left: 1px solid var(--app-surface-border);
+  box-shadow: -18px 0 50px rgba(15, 23, 42, 0.12);
+  outline: none;
+}
+
+.queue-header {
+  min-height: 72px;
+  padding: 14px 16px 12px 20px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  border-bottom: 1px solid var(--app-surface-border);
+}
+
+.queue-heading {
+  min-width: 0;
+}
+
+.queue-heading h2,
+.queue-heading p {
+  margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.queue-heading h2 {
+  font-size: 17px;
+  font-weight: 650;
+}
+
+.queue-heading p {
+  margin-top: 4px;
+  color: var(--el-text-color-secondary);
+  font-size: 12px;
+}
+
+.queue-close {
+  width: 32px;
+  height: 32px;
+  flex-shrink: 0;
+  border: 0;
+  border-radius: 50%;
+  color: var(--el-text-color-secondary);
+  background: transparent;
+  cursor: pointer;
+}
+
+.queue-close:hover {
+  color: var(--el-color-primary);
+  background: var(--hover-bg-color);
+}
+
+.queue-list {
+  flex: 1;
+  min-height: 0;
+  padding: 8px;
+  overflow-y: auto;
+}
+
+.queue-item {
+  width: 100%;
+  min-height: 58px;
+  padding: 8px 10px;
+  display: grid;
+  grid-template-columns: 28px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  border: 0;
+  border-radius: var(--app-radius-md);
+  color: inherit;
+  background: transparent;
+  text-align: left;
+  cursor: pointer;
+}
+
+.queue-item:hover,
+.queue-item:focus-visible {
+  background: var(--hover-bg-color);
+  outline: none;
+}
+
+.queue-item.is-current {
+  color: var(--el-color-primary);
+  background: var(--active-item-bg);
+}
+
+.queue-item:disabled {
+  opacity: 0.48;
+  cursor: default;
+}
+
+.queue-item-index {
+  color: var(--el-text-color-secondary);
+  font-size: 11px;
+  text-align: center;
+  font-variant-numeric: tabular-nums;
+}
+
+.queue-item-main {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.queue-item-main strong,
+.queue-item-main span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.queue-item-main strong {
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.queue-item-main span,
+.queue-item-source {
+  color: var(--el-text-color-secondary);
+  font-size: 11px;
+}
+
+.queue-item-source {
+  max-width: 74px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.queue-empty {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  color: var(--el-text-color-secondary);
+}
+
+.queue-empty .el-icon {
+  font-size: 28px;
+}
+
+.queue-empty p {
+  margin: 0;
+  font-size: 13px;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .queue-panel {
+    animation: queue-slide-in 180ms cubic-bezier(0.22, 1, 0.36, 1);
+  }
+}
+
+@keyframes queue-slide-in {
+  from {
+    opacity: 0;
+    transform: translateX(22px);
+  }
+}
+</style>

--- a/src/components/feature/PlayerBar/PlayerBar.css
+++ b/src/components/feature/PlayerBar/PlayerBar.css
@@ -1,6 +1,6 @@
 .player-bar {
   display: grid;
-  grid-template-columns: minmax(150px, 168px) minmax(0, 1fr) minmax(140px, 180px);
+  grid-template-columns: minmax(150px, 190px) minmax(0, 1fr) minmax(180px, 220px);
   align-items: center;
   height: var(--app-player-height, 64px);
   padding: 0 16px;
@@ -85,8 +85,28 @@ html.dark .player-bar {
   margin-top: 2px;
 }
 
+.playback-status {
+  margin-top: 2px;
+  color: var(--el-color-primary);
+  font-size: 11px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .artist-link {
+  padding: 0;
+  border: 0;
+  color: inherit;
+  background: transparent;
+  font: inherit;
   cursor: pointer;
+}
+
+.artist-link:focus-visible {
+  border-radius: 2px;
+  outline: 2px solid color-mix(in srgb, var(--el-color-primary) 44%, transparent);
+  outline-offset: 1px;
 }
 
 .artist-link:hover {
@@ -180,6 +200,21 @@ html.dark .player-bar {
   font-weight: 500;
 }
 
+.player-progress .time-display-toggle {
+  padding: 2px 0;
+  border: 0;
+  border-radius: 3px;
+  background: transparent;
+  cursor: pointer;
+}
+
+.player-progress .time-display-toggle:hover,
+.player-progress .time-display-toggle:focus-visible {
+  color: var(--el-color-primary);
+  outline: 2px solid color-mix(in srgb, var(--el-color-primary) 36%, transparent);
+  outline-offset: 1px;
+}
+
 .player-progress .progress-slider {
   flex: 1;
 }
@@ -241,7 +276,8 @@ html.dark .player-bar {
   justify-content: flex-end;
 }
 
-.play-mode-btn {
+.play-mode-btn,
+.queue-btn {
   width: var(--app-icon-btn-sm);
   height: var(--app-icon-btn-sm);
   padding: 0;
@@ -255,10 +291,16 @@ html.dark .player-bar {
     transform var(--app-control-transition);
 }
 
-.play-mode-btn:hover {
+.play-mode-btn:hover,
+.queue-btn:hover {
   background: var(--app-icon-button-hover-bg) !important;
   border-color: var(--app-button-border) !important;
   color: var(--app-icon-button-hover-color) !important;
+}
+
+.play-mode-btn.is-active {
+  color: var(--el-color-primary) !important;
+  background: var(--active-item-bg) !important;
 }
 
 /* 内联音量条：扬声器图标 + 横向轨道，常驻播放条 */
@@ -279,6 +321,16 @@ html.dark .player-bar {
   width: 18px;
   height: 18px;
   color: var(--el-text-color-secondary);
+  padding: 0;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+}
+
+.volume-speaker-icon:hover,
+.volume-speaker-icon:focus-visible {
+  color: var(--el-color-primary);
+  outline: none;
 }
 
 .volume-speaker-icon svg {

--- a/src/components/feature/PlayerBar/PlayerBar.vue
+++ b/src/components/feature/PlayerBar/PlayerBar.vue
@@ -9,9 +9,15 @@ import {
   Sort,
   Refresh,
   RefreshRight,
+  Tickets,
 } from "@element-plus/icons-vue";
-import { PlayMode, type MusicFile, type SongInfo } from "@/types/model";
-import { getLocalMusicDisplayInfo } from "@/utils/songUtils";
+import {
+  PlayMode,
+  type MusicFile,
+  type PlaybackPhase,
+  type SongInfo,
+} from "@/types/model";
+import { formatDuration, getLocalMusicDisplayInfo } from "@/utils/songUtils";
 import CoverImage from "@/components/base/CoverImage/CoverImage.vue";
 import { useArtistNavigation } from "@/composables/useArtistNavigation";
 import { useCoverLoader } from "@/composables/useCoverLoader";
@@ -22,15 +28,21 @@ import { useLocalMusicStore } from "@/stores/localMusicStore";
 
 const { t, locale } = useI18n();
 
-const props = defineProps<{
-  currentMusic: MusicFile | null;
-  currentOnlineSong: SongInfo | null;
-  isPlaying: boolean;
-  playMode: PlayMode;
-  volume: number;
-  currentPlayTime: number;
-  currentTrackDuration: number;
-}>();
+const props = withDefaults(
+  defineProps<{
+    currentMusic: MusicFile | null;
+    currentOnlineSong: SongInfo | null;
+    isPlaying: boolean;
+    playbackPhase?: PlaybackPhase;
+    playMode: PlayMode;
+    volume: number;
+    currentPlayTime: number;
+    currentTrackDuration: number;
+  }>(),
+  {
+    playbackPhase: "idle",
+  }
+);
 
 const emit = defineEmits([
   "toggle-play",
@@ -38,6 +50,7 @@ const emit = defineEmits([
   "next",
   "previous",
   "toggle-play-mode",
+  "toggle-queue",
   "show-immersive",
   "seek",
 ]);
@@ -46,11 +59,14 @@ const artistStore = useArtistStore();
 const onlineStore = useOnlineMusicStore();
 const localStore = useLocalMusicStore();
 const volumeSliderValue = ref(props.volume);
+const lastAudibleVolume = ref(props.volume > 0 ? props.volume : 50);
+const showRemainingTime = ref(false);
 
 watch(
   () => props.volume,
   (value) => {
     if (value !== volumeSliderValue.value) volumeSliderValue.value = value;
+    if (value > 0) lastAudibleVolume.value = value;
   }
 );
 
@@ -58,6 +74,10 @@ function handleVolumeChange(value: number | number[]) {
   const nextValue = Array.isArray(value) ? (value[0] ?? 0) : value;
   volumeSliderValue.value = nextValue;
   emit("volume-change", nextValue);
+}
+
+function toggleMute() {
+  handleVolumeChange(props.volume > 0 ? 0 : lastAudibleVolume.value);
 }
 
 const currentSongName = computed(() => {
@@ -69,6 +89,16 @@ const currentSongName = computed(() => {
 });
 
 const songTitle = computed(() => currentSongName.value);
+const isLoading = computed(() => props.playbackPhase !== "idle");
+const playbackStatus = computed(() =>
+  props.playbackPhase === "resolving"
+    ? t("playerBar.resolving")
+    : t("playerBar.buffering")
+);
+const remainingTimeDisplay = computed(
+  () =>
+    `-${formatDuration(Math.max(0, props.currentTrackDuration - props.currentPlayTime))}`
+);
 
 const currentArtistDisplay = computed(() => {
   void locale.value;
@@ -153,21 +183,26 @@ const {
       </div>
       <div class="song-info">
         <div class="song-name" :title="songTitle">{{ songTitle }}</div>
+        <div v-if="isLoading" class="playback-status" role="status">
+          {{ playbackStatus }}
+        </div>
         <div
-          v-if="currentArtistDisplay"
+          v-else-if="currentArtistDisplay"
           class="artist-name"
           :title="currentArtistDisplay"
         >
           <template v-if="artistNames.length">
             <template v-for="(a, idx) in artistNames" :key="a + idx">
-              <span
+              <component
+                :is="canNavigateArtist ? 'button' : 'span'"
+                :type="canNavigateArtist ? 'button' : undefined"
                 class="artist-part"
                 :class="{ 'artist-link': canNavigateArtist }"
                 @click.stop="navigateArtistByName(a)"
-                :title="`${a}（点击查看）`"
+                :title="canNavigateArtist ? t('artist.open', { name: a }) : a"
               >
                 {{ a }}
-              </span>
+              </component>
               <span v-if="idx < artistNames.length - 1" class="artist-sep">, </span>
             </template>
           </template>
@@ -204,6 +239,7 @@ const {
           <el-button
             class="control-btn play-btn app-play-button"
             :icon="isPlaying ? VideoPause : VideoPlay"
+            :loading="isLoading"
             :disabled="!currentMusic && !currentOnlineSong"
             @click="emit('toggle-play')"
           />
@@ -237,29 +273,51 @@ const {
           @input="handleProgressInput"
           @change="handleProgressChange"
         />
-        <span class="time-display">{{ durationDisplay }}</span>
+        <button
+          type="button"
+          class="time-display time-display-toggle"
+          :aria-label="t('playerBar.toggleRemainingTime')"
+          @click="showRemainingTime = !showRemainingTime"
+        >
+          {{ showRemainingTime ? remainingTimeDisplay : durationDisplay }}
+        </button>
       </div>
     </div>
 
     <!-- 右侧：播放模式 + 内联音量条 -->
     <div class="player-right">
+      <el-tooltip :content="t('playerBar.queue')" placement="top" effect="light">
+        <el-button
+          class="queue-btn app-icon-button"
+          circle
+          :icon="Tickets"
+          :disabled="!currentMusic && !currentOnlineSong"
+          :aria-label="t('playerBar.queue')"
+          @click="emit('toggle-queue')"
+        />
+      </el-tooltip>
       <el-tooltip :content="playModeTooltip" placement="top" effect="light">
         <el-button
           class="play-mode-btn app-icon-button"
-          :class="{ 'is-active': true }"
+          :class="{ 'is-active': playMode !== PlayMode.SEQUENTIAL }"
           circle
           :icon="playModeIcon"
           @click="emit('toggle-play-mode')"
         />
       </el-tooltip>
       <div class="volume-bar">
-        <span class="volume-speaker-icon" aria-hidden="true">
+        <button
+          type="button"
+          class="volume-speaker-icon"
+          :aria-label="t(volume > 0 ? 'playerBar.mute' : 'playerBar.unmute')"
+          @click="toggleMute"
+        >
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
             <path
               d="M3 9v6h4l5 5V4L7 9H3zm13.5 3c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77s-2.99-7.86-7-8.77z"
             />
           </svg>
-        </span>
+        </button>
         <el-slider
           v-model="volumeSliderValue"
           :max="100"

--- a/src/components/feature/SettingsWindow/SettingsWindow.css
+++ b/src/components/feature/SettingsWindow/SettingsWindow.css
@@ -87,8 +87,32 @@
 }
 
 .cache-control,
-.setting-actions {
+.setting-actions,
+.service-control {
   gap: 6px;
+}
+
+.service-state {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  color: var(--el-text-color-secondary);
+  font-size: 13px;
+}
+
+.service-state-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--el-color-warning);
+}
+
+.service-state.is-available .service-state-dot {
+  background: var(--el-color-success);
+}
+
+.service-state.is-unavailable .service-state-dot {
+  background: var(--el-color-danger);
 }
 
 .theme-select,

--- a/src/components/feature/SettingsWindow/SettingsWindow.vue
+++ b/src/components/feature/SettingsWindow/SettingsWindow.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted } from "vue";
+import { computed, ref, onMounted, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import {
   Brush,
@@ -10,11 +10,13 @@ import {
   Delete,
   FolderOpened,
   RefreshLeft,
+  Refresh,
 } from "@element-plus/icons-vue";
 import { ElMessage } from "element-plus";
 import { open } from "@tauri-apps/plugin-dialog";
 import { useThemeStore, type ThemeMode } from "@/stores/themeStore";
 import { useLocalMusicStore } from "@/stores/localMusicStore";
+import { useOnlineServiceStore } from "@/stores/onlineServiceStore";
 import { enable, isEnabled, disable } from "@tauri-apps/plugin-autostart";
 import { setLocale, getLocale, type LocaleKey } from "@/i18n";
 import {
@@ -28,12 +30,33 @@ import PageLayout from "@/components/layout/PageLayout/PageLayout.vue";
 const { t } = useI18n();
 const themeStore = useThemeStore();
 const localStore = useLocalMusicStore();
+const onlineServiceStore = useOnlineServiceStore();
 const downloadPath = ref("");
 const autoStartEnabled = ref(false);
 const currentLocale = ref<LocaleKey>(getLocale());
 const onlineCacheSize = ref(0);
 const onlineCachePath = ref("");
 const clearingCache = ref(false);
+const serviceStatusLabel = computed(() => {
+  if (onlineServiceStore.state === "checking") return t("onlineService.checking");
+  if (onlineServiceStore.state === "restarting") return t("onlineService.restarting");
+  return onlineServiceStore.isAvailable
+    ? t("onlineService.available")
+    : t("onlineService.unavailable");
+});
+
+watch(
+  () => localStore.defaultDirectory,
+  (directory) => {
+    if (directory) downloadPath.value = directory;
+  },
+  { immediate: true }
+);
+
+async function refreshOnlineService() {
+  await onlineServiceStore.ensureStarted();
+  await onlineServiceStore.checkNow();
+}
 
 const localeOptions: { value: LocaleKey; labelKey: string }[] = [
   { value: "zh", labelKey: "settings.languageZh" },
@@ -144,8 +167,6 @@ const handleAutoStartChange = async (value: boolean) => {
 
 onMounted(async () => {
   try {
-    await localStore.initializeLocalLibrary();
-    themeStore.initializeTheme();
     const dir = localStore.getDefaultDirectory();
     if (dir) downloadPath.value = dir;
     await refreshOnlineCachePath();
@@ -213,6 +234,27 @@ onMounted(async () => {
           <label>{{ t("settings.autoStart") }}</label>
           <div class="setting-control">
             <el-switch v-model="autoStartEnabled" @change="handleAutoStartChange" />
+          </div>
+        </div>
+        <div class="setting-row">
+          <label>{{ t("settings.serviceStatus") }}</label>
+          <div class="setting-control service-control">
+            <span
+              class="service-state"
+              :class="`is-${onlineServiceStore.state}`"
+              role="status"
+            >
+              <span class="service-state-dot" />
+              {{ serviceStatusLabel }}
+            </span>
+            <el-button
+              circle
+              :icon="Refresh"
+              :loading="onlineServiceStore.isChecking || onlineServiceStore.isRestarting"
+              :aria-label="t('settings.refreshService')"
+              class="settings-action-btn app-icon-button"
+              @click="refreshOnlineService"
+            />
           </div>
         </div>
       </div>

--- a/src/components/feature/TrackList/TrackList.vue
+++ b/src/components/feature/TrackList/TrackList.vue
@@ -137,6 +137,7 @@ function handleActivate(item: TrackRowModel) {
   width: 100%;
   padding: 0 4px 12px;
   box-sizing: border-box;
+  margin-inline: auto;
 }
 
 .track-list--reading .track-list__rows {

--- a/src/components/feature/TrackList/TrackRow.vue
+++ b/src/components/feature/TrackList/TrackRow.vue
@@ -73,16 +73,11 @@ function handleActivate() {
       rowHeight ? { height: `${rowHeight}px`, minHeight: `${rowHeight}px` } : undefined
     "
     :title="`${item.title} — ${item.artist}`"
-    :tabindex="item.disabled ? -1 : 0"
-    role="button"
     :aria-current="item.isCurrent ? 'true' : undefined"
     :aria-disabled="item.disabled || undefined"
     @click="handleRowClick"
-    @keydown.enter.space.prevent="handleRowClick"
     @pointerenter="scheduleIntent"
     @pointerleave="cancelIntent"
-    @focus="scheduleIntent"
-    @blur="cancelIntent"
   >
     <div class="track-row__play">
       <el-checkbox
@@ -116,8 +111,13 @@ function handleActivate() {
         {{ item.title }}
       </div>
       <div class="track-row__meta">
-        {{ item.artist }}<template v-if="item.album"> · {{ item.album }}</template>
+        {{ item.artist
+        }}<span v-if="item.album" class="track-row__meta-album"> · {{ item.album }}</span>
       </div>
+    </div>
+
+    <div v-if="item.album" class="track-row__album" :title="item.album">
+      {{ item.album }}
     </div>
 
     <div v-if="item.durationLabel" class="track-row__duration">
@@ -134,7 +134,7 @@ function handleActivate() {
 .track-row {
   position: relative;
   min-height: var(--app-track-row-height);
-  margin-bottom: 2px;
+  margin-bottom: 0;
   padding: var(--app-track-row-padding-y) var(--app-track-row-padding-x);
   display: flex;
   align-items: center;
@@ -185,9 +185,19 @@ function handleActivate() {
 
 .track-row__play,
 .track-row__cover,
+.track-row__album,
 .track-row__duration,
 .track-row__actions {
   flex-shrink: 0;
+}
+
+.track-row__album {
+  width: clamp(140px, 20vw, 260px);
+  overflow: hidden;
+  color: var(--el-text-color-secondary);
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .track-row__cover {
@@ -208,6 +218,10 @@ function handleActivate() {
   text-overflow: ellipsis;
   white-space: nowrap;
   letter-spacing: 0;
+}
+
+.track-row__meta-album {
+  display: none;
 }
 
 .track-row__title {
@@ -297,6 +311,16 @@ function handleActivate() {
     gap: 10px;
     padding-right: 8px;
     padding-left: 8px;
+  }
+}
+
+@media (max-width: 1100px) {
+  .track-row__album {
+    display: none;
+  }
+
+  .track-row__meta-album {
+    display: inline;
   }
 }
 </style>

--- a/src/components/layout/HeaderBar/HeaderBar.css
+++ b/src/components/layout/HeaderBar/HeaderBar.css
@@ -340,6 +340,8 @@ html.dark .search-history-chip:hover {
   overflow: hidden;
   color: var(--app-icon-button-color);
   border: 1px solid transparent;
+  padding: 0;
+  background: transparent;
   transition:
     color var(--app-control-transition),
     background var(--app-control-transition),

--- a/src/components/layout/HeaderBar/HeaderBar.vue
+++ b/src/components/layout/HeaderBar/HeaderBar.vue
@@ -250,27 +250,30 @@ onUnmounted(clearBlurTimer);
       </el-tooltip>
       <!-- 非 macOS 平台显示窗口控制按钮 -->
       <div v-if="!isMacPlatform" class="window-controls">
-        <div
+        <button
+          type="button"
           class="header-button window-button"
           :title="t('header.minimize')"
           @click="minimize"
         >
           <el-icon><Minus /></el-icon>
-        </div>
-        <div
+        </button>
+        <button
+          type="button"
           class="header-button window-button"
           :title="isMaximized ? t('header.restore') : t('header.maximize')"
           @click="toggleMaximize"
         >
           <el-icon><component :is="maximizeIcon" /></el-icon>
-        </div>
-        <div
+        </button>
+        <button
+          type="button"
           class="header-button window-button close"
           :title="t('header.close')"
           @click="close"
         >
           <el-icon><Close /></el-icon>
-        </div>
+        </button>
       </div>
     </div>
   </div>

--- a/src/components/layout/Sidebar/Sidebar.css
+++ b/src/components/layout/Sidebar/Sidebar.css
@@ -31,12 +31,24 @@
   gap: 11px;
   min-height: 40px;
   padding: 0 11px;
+  width: 100%;
+  border: 0;
   border-radius: var(--app-radius-md);
   cursor: pointer;
   color: var(--sidebar-text, var(--el-text-color-regular));
+  background: transparent;
+  font: inherit;
+  text-align: left;
   transition:
     color 0.2s ease,
     background 0.2s ease;
+}
+
+.nav-item:focus-visible,
+.playlist-section-toggle:focus-visible,
+.playlist-section-add:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--el-color-primary) 42%, transparent);
+  outline-offset: 1px;
 }
 
 .nav-item:hover {
@@ -106,12 +118,27 @@ html.dark .playlist-section,
   letter-spacing: 0;
   color: var(--el-text-color-secondary);
   opacity: 0.9;
-  cursor: pointer;
+  cursor: default;
   border-radius: var(--app-radius-sm);
   transition:
     color 0.2s ease,
     background 0.2s ease,
     opacity 0.2s ease;
+}
+
+.playlist-section-toggle {
+  min-width: 0;
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0;
+  border: 0;
+  color: inherit;
+  background: transparent;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
 }
 
 .playlist-section-title:hover {
@@ -155,6 +182,8 @@ html.dark .playlist-section,
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  border: 0;
+  background: transparent;
 }
 
 .playlist-section-add:hover {

--- a/src/components/layout/Sidebar/Sidebar.vue
+++ b/src/components/layout/Sidebar/Sidebar.vue
@@ -72,43 +72,46 @@ function goToPlaylist(id: string) {
 <template>
   <aside class="sidebar">
     <nav class="sidebar-nav">
-      <div
+      <button
         v-for="item in navItems"
         :key="item.path"
+        type="button"
         class="nav-item"
         :class="{ 'is-active': isActive(item) }"
         @click="goTo(item)"
       >
         <el-icon class="nav-icon"><component :is="item.icon" /></el-icon>
         <span class="nav-label">{{ t(item.labelKey) }}</span>
-      </div>
+      </button>
 
       <div class="playlist-section" :class="{ 'is-collapsed': !playlistSectionExpanded }">
-        <div
-          class="playlist-section-title"
-          role="button"
-          tabindex="0"
-          :aria-expanded="playlistSectionExpanded"
-          @click="togglePlaylistSection"
-          @keydown.enter.space.prevent="togglePlaylistSection"
-        >
-          <el-icon class="chevron"><ArrowDown /></el-icon>
-          <el-icon class="title-icon"><List /></el-icon>
-          <span class="playlist-section-title-text">{{ t("playlist.title") }}</span>
-          <el-icon
+        <div class="playlist-section-title">
+          <button
+            type="button"
+            class="playlist-section-toggle"
+            :aria-expanded="playlistSectionExpanded"
+            @click="togglePlaylistSection"
+          >
+            <el-icon class="chevron"><ArrowDown /></el-icon>
+            <el-icon class="title-icon"><List /></el-icon>
+            <span class="playlist-section-title-text">{{ t("playlist.title") }}</span>
+          </button>
+          <button
+            type="button"
             class="playlist-section-add"
             :title="t('playlist.newPlaylist')"
             :aria-label="t('playlist.newPlaylist')"
-            @click.stop="goToNewPlaylist"
+            @click="goToNewPlaylist"
           >
-            <Plus />
-          </el-icon>
+            <el-icon><Plus /></el-icon>
+          </button>
         </div>
         <Transition name="playlist-body">
           <div v-show="playlistSectionExpanded" class="playlist-section-body">
-            <div
+            <button
               v-for="pl in playlistStore.playlists"
               :key="pl.id"
+              type="button"
               class="nav-item nav-item-playlist"
               :class="{ 'is-active': isPlaylistActive(pl.id) }"
               @click="goToPlaylist(pl.id)"
@@ -116,7 +119,7 @@ function goToPlaylist(id: string) {
               <span class="nav-label" :title="pl.name">{{
                 pl.name || t("playlist.unnamed")
               }}</span>
-            </div>
+            </button>
           </div>
         </Transition>
       </div>

--- a/src/composables/useCoverBrightness.ts
+++ b/src/composables/useCoverBrightness.ts
@@ -7,6 +7,18 @@ interface CoverBrightnessState {
 }
 
 const MAX_ANALYSIS_IMAGE_SIZE = 96;
+const MAX_BRIGHTNESS_CACHE_ENTRIES = 100;
+const brightnessCache = new Map<string, number>();
+
+function cacheBrightness(url: string, brightness: number) {
+  brightnessCache.delete(url);
+  brightnessCache.set(url, brightness);
+  while (brightnessCache.size > MAX_BRIGHTNESS_CACHE_ENTRIES) {
+    const oldest = brightnessCache.keys().next().value;
+    if (!oldest) break;
+    brightnessCache.delete(oldest);
+  }
+}
 
 function getAdjustedBrightness(averageBrightness: number): number {
   if (averageBrightness < 0.3) return 1.28;
@@ -70,6 +82,7 @@ export function useCoverBrightness(imageUrl: Ref<string>) {
       state.value.brightness =
         averageBrightness === null ? 0.7 : getAdjustedBrightness(averageBrightness);
       state.value.isAnalyzed = true;
+      cacheBrightness(url, state.value.brightness);
     } catch (error) {
       if (currentAnalysisId !== analysisId) return;
       console.error("分析封面图片亮度失败:", error);
@@ -87,7 +100,16 @@ export function useCoverBrightness(imageUrl: Ref<string>) {
       const currentAnalysisId = ++analysisId;
       state.value.isAnalyzed = false;
       if (url) {
-        void analyze(url, currentAnalysisId);
+        const cached = brightnessCache.get(url);
+        if (cached !== undefined) {
+          state.value = {
+            brightness: cached,
+            isAnalyzing: false,
+            isAnalyzed: true,
+          };
+        } else {
+          void analyze(url, currentAnalysisId);
+        }
       } else {
         state.value.isAnalyzing = false;
       }

--- a/src/composables/useLocalCoverCache.ts
+++ b/src/composables/useLocalCoverCache.ts
@@ -16,7 +16,7 @@ export function useLocalCoverCache<T>(options: UseLocalCoverCacheOptions<T>) {
   const coverByKey = reactive<Record<string, string>>({});
   const queue: T[] = [];
   const pendingKeys = new Set<string>();
-  const cachedKeys: string[] = [];
+  const cacheOrder = new Map<string, true>();
   let running = 0;
 
   function normalizeKey(item: T): string {
@@ -25,13 +25,14 @@ export function useLocalCoverCache<T>(options: UseLocalCoverCacheOptions<T>) {
 
   function setCachedCover(key: string, value: string) {
     const maxEntries = options.maxEntries ?? DEFAULT_MAX_COVER_CACHE_ENTRIES;
-    const existingIndex = cachedKeys.indexOf(key);
-    if (existingIndex >= 0) cachedKeys.splice(existingIndex, 1);
-    cachedKeys.push(key);
+    cacheOrder.delete(key);
+    cacheOrder.set(key, true);
     coverByKey[key] = value;
-    while (cachedKeys.length > maxEntries) {
-      const keyToDelete = cachedKeys.shift();
-      if (keyToDelete) delete coverByKey[keyToDelete];
+    while (cacheOrder.size > maxEntries) {
+      const keyToDelete = cacheOrder.keys().next().value;
+      if (!keyToDelete) break;
+      cacheOrder.delete(keyToDelete);
+      delete coverByKey[keyToDelete];
     }
   }
 
@@ -79,11 +80,8 @@ export function useLocalCoverCache<T>(options: UseLocalCoverCacheOptions<T>) {
   function getCover(item: T): string {
     const key = normalizeKey(item);
     if (coverByKey[key] !== undefined) {
-      const existingIndex = cachedKeys.indexOf(key);
-      if (existingIndex >= 0) {
-        cachedKeys.splice(existingIndex, 1);
-        cachedKeys.push(key);
-      }
+      cacheOrder.delete(key);
+      cacheOrder.set(key, true);
     }
     return coverByKey[key] ?? "";
   }
@@ -91,7 +89,7 @@ export function useLocalCoverCache<T>(options: UseLocalCoverCacheOptions<T>) {
   function clear() {
     queue.length = 0;
     pendingKeys.clear();
-    cachedKeys.length = 0;
+    cacheOrder.clear();
     for (const key of Object.keys(coverByKey)) delete coverByKey[key];
   }
 

--- a/src/composables/usePlaybackQueue.ts
+++ b/src/composables/usePlaybackQueue.ts
@@ -1,5 +1,5 @@
 import { ref } from "vue";
-import { PlayMode, ViewMode, type Playlist, type SongInfo } from "@/types/model";
+import { PlayMode, type Playlist, type SongInfo } from "@/types/model";
 
 const MAX_PREFETCHED_ONLINE_SONG_IDS = 300;
 const MAX_CONCURRENT_ONLINE_PREFETCHES = 2;
@@ -11,8 +11,8 @@ export interface PlayOnlineOptions {
 
 export function usePlaybackQueue(options: {
   getPlayMode: () => PlayMode;
-  getViewMode: () => ViewMode;
-  getFallbackOnlineQueue: () => SongInfo[];
+  getViewMode?: () => unknown;
+  getFallbackOnlineQueue?: () => SongInfo[];
   getCurrentPlaylistId: () => string | null;
   setCurrentPlaylistId: (id: string | null) => void;
   getPlaylist: (id: string) => Playlist | undefined;
@@ -26,17 +26,35 @@ export function usePlaybackQueue(options: {
     currentOnlineQueue.value = [];
   }
 
-  function applyOnlinePlaybackContext(playOptions?: PlayOnlineOptions) {
-    if (!playOptions?.fromPlaylistId) options.setCurrentPlaylistId(null);
-    currentOnlineQueue.value = playOptions?.fromPlaylistId
-      ? []
-      : [...(playOptions?.queue ?? [])];
+  function applyOnlinePlaybackContext(playOptions?: PlayOnlineOptions): void;
+  function applyOnlinePlaybackContext(
+    song: SongInfo,
+    playOptions?: PlayOnlineOptions
+  ): void;
+  function applyOnlinePlaybackContext(
+    songOrOptions?: SongInfo | PlayOnlineOptions,
+    optionsArg?: PlayOnlineOptions
+  ) {
+    const song = songOrOptions && "id" in songOrOptions ? songOrOptions : null;
+    const playOptions = song
+      ? optionsArg
+      : (songOrOptions as PlayOnlineOptions | undefined);
+    if (playOptions?.fromPlaylistId) {
+      options.setCurrentPlaylistId(playOptions.fromPlaylistId);
+      currentOnlineQueue.value = [];
+      return;
+    }
+
+    options.setCurrentPlaylistId(null);
+    if (playOptions?.queue) {
+      currentOnlineQueue.value = [...playOptions.queue];
+    } else if (song && !currentOnlineQueue.value.some((item) => item.id === song.id)) {
+      currentOnlineQueue.value = [song];
+    }
   }
 
   function getActiveOnlineQueue(): SongInfo[] {
-    return currentOnlineQueue.value.length > 0
-      ? currentOnlineQueue.value
-      : options.getFallbackOnlineQueue();
+    return currentOnlineQueue.value;
   }
 
   function getNextOnlineSongForPrefetch(song: SongInfo): SongInfo | null {
@@ -59,9 +77,7 @@ export function usePlaybackQueue(options: {
     }
 
     const queue = getActiveOnlineQueue();
-    if (options.getViewMode() !== ViewMode.ONLINE || queue.length <= 1) {
-      return null;
-    }
+    if (queue.length <= 1) return null;
     const currentIndex = queue.findIndex((item) => item.id === song.id);
     if (currentIndex === -1) return null;
     return queue[(currentIndex + 1) % queue.length];

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -21,8 +21,11 @@ export const i18n = createI18n({
   },
 });
 
+document.documentElement.lang = initialLocale === "zh" ? "zh-CN" : "en";
+
 export function setLocale(locale: LocaleKey) {
   i18n.global.locale.value = locale;
+  document.documentElement.lang = locale === "zh" ? "zh-CN" : "en";
   localStorage.setItem(STORAGE_KEY_LOCALE, locale);
 }
 

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -15,6 +15,7 @@ export default {
     warm: "Warm",
     cancel: "Cancel",
     confirmDelete: "Delete",
+    close: "Close",
   },
   playlist: {
     title: "Playlists",
@@ -71,6 +72,9 @@ export default {
     about: "About",
     aboutDesc: "A music player built with Tauri and Vue",
     language: "Language",
+    onlineService: "Online Service",
+    serviceStatus: "Service status",
+    refreshService: "Start or refresh online service",
   },
   musicList: {
     title: "Library",
@@ -82,6 +86,7 @@ export default {
     cancelSelect: "Cancel",
     addSelectedToPlaylist: "Add to playlist",
     selectedCount: "{count} selected",
+    updating: "Updating library in the background…",
   },
   onlineMusic: {
     title: "Search",
@@ -97,6 +102,7 @@ export default {
   },
   artist: {
     backToSearch: "Back to search",
+    open: "Open artist: {name}",
   },
   playerBar: {
     noSong: "No song selected",
@@ -104,6 +110,14 @@ export default {
     next: "Next",
     play: "Play",
     pause: "Pause",
+    resolving: "Resolving stream…",
+    buffering: "Buffering…",
+    queue: "Play Queue",
+    currentQueue: "Current queue",
+    queueEmpty: "The queue is empty",
+    mute: "Mute",
+    unmute: "Unmute",
+    toggleRemainingTime: "Toggle duration and remaining time",
     sequential: "Sequential",
     random: "Shuffle",
     repeatOne: "Repeat One",

--- a/src/locales/zh.ts
+++ b/src/locales/zh.ts
@@ -15,6 +15,7 @@ export default {
     warm: "暖色",
     cancel: "取消",
     confirmDelete: "确定删除",
+    close: "关闭",
   },
   playlist: {
     title: "播放列表",
@@ -71,6 +72,9 @@ export default {
     about: "关于",
     aboutDesc: "一个基于 Tauri 和 Vue 的音乐播放器",
     language: "语言",
+    onlineService: "在线服务",
+    serviceStatus: "服务状态",
+    refreshService: "启动或刷新在线服务",
   },
   musicList: {
     title: "曲库",
@@ -82,6 +86,7 @@ export default {
     cancelSelect: "取消多选",
     addSelectedToPlaylist: "添加到播放列表",
     selectedCount: "已选 {count} 首",
+    updating: "正在后台更新曲库…",
   },
   onlineMusic: {
     title: "搜索",
@@ -97,6 +102,7 @@ export default {
   },
   artist: {
     backToSearch: "返回搜索",
+    open: "查看歌手：{name}",
   },
   playerBar: {
     noSong: "未选择歌曲",
@@ -104,6 +110,14 @@ export default {
     next: "下一曲",
     play: "播放",
     pause: "暂停",
+    resolving: "正在获取播放地址…",
+    buffering: "正在缓冲…",
+    queue: "播放队列",
+    currentQueue: "当前队列",
+    queueEmpty: "队列中还没有歌曲",
+    mute: "静音",
+    unmute: "恢复音量",
+    toggleRemainingTime: "切换总时长与剩余时间",
     sequential: "顺序播放",
     random: "随机播放",
     repeatOne: "单曲循环",

--- a/src/stores/localMusicStore.ts
+++ b/src/stores/localMusicStore.ts
@@ -12,6 +12,7 @@ export const useLocalMusicStore = defineStore("localMusic", () => {
   const searchKeyword = ref("");
   const currentDirectory = ref("");
   const isLoading = ref(false);
+  const isRefreshing = ref(false);
 
   const defaultDirectory = ref<string | null>(null);
   const isInitialized = ref(false);
@@ -36,7 +37,8 @@ export const useLocalMusicStore = defineStore("localMusic", () => {
 
   async function loadMusicFiles(path?: string, options?: { restoreCache?: boolean }) {
     const requestId = ++latestLoadRequestId;
-    isLoading.value = true;
+    let restoredCachedFiles = false;
+    isLoading.value = musicFiles.value.length === 0;
     try {
       if (path) currentDirectory.value = path;
       if (options?.restoreCache) {
@@ -45,8 +47,33 @@ export const useLocalMusicStore = defineStore("localMusic", () => {
           defaultDirectory: defaultDirectory.value,
         });
         if (requestId !== latestLoadRequestId) return;
-        if (cachedFiles.length > 0) musicFiles.value = cachedFiles;
+        if (cachedFiles.length > 0) {
+          musicFiles.value = cachedFiles;
+          restoredCachedFiles = true;
+          isLoading.value = false;
+        }
       }
+
+      const refresh = refreshMusicFilesFromDisk(requestId, path);
+      if (restoredCachedFiles) {
+        void refresh;
+        return;
+      }
+      await refresh;
+    } catch (error) {
+      if (requestId !== latestLoadRequestId) return;
+      console.error("加载音乐文件失败:", error);
+      ElMessage.error(`${i18n.global.t("errors.loadMusicFailed")}: ${error}`);
+    } finally {
+      if (requestId === latestLoadRequestId && !restoredCachedFiles) {
+        isLoading.value = false;
+      }
+    }
+  }
+
+  async function refreshMusicFilesFromDisk(requestId: number, path?: string) {
+    isRefreshing.value = true;
+    try {
       const files = await scanFiles({
         path: path || null,
         defaultDirectory: defaultDirectory.value,
@@ -55,10 +82,13 @@ export const useLocalMusicStore = defineStore("localMusic", () => {
       musicFiles.value = files;
     } catch (error) {
       if (requestId !== latestLoadRequestId) return;
-      console.error("加载音乐文件失败:", error);
+      console.error("刷新音乐文件失败:", error);
       ElMessage.error(`${i18n.global.t("errors.loadMusicFailed")}: ${error}`);
     } finally {
-      if (requestId === latestLoadRequestId) isLoading.value = false;
+      if (requestId === latestLoadRequestId) {
+        isLoading.value = false;
+        isRefreshing.value = false;
+      }
     }
   }
 
@@ -150,6 +180,7 @@ export const useLocalMusicStore = defineStore("localMusic", () => {
     searchKeyword,
     currentDirectory,
     isLoading,
+    isRefreshing,
     defaultDirectory,
     isInitialized,
     loadMusicFiles,

--- a/src/stores/onlineServiceStore.ts
+++ b/src/stores/onlineServiceStore.ts
@@ -1,7 +1,11 @@
 import { computed, ref } from "vue";
 import { defineStore } from "pinia";
 import type { OnlineServiceStatus } from "@/types/model";
-import { checkOnlineServiceStatus, restartOnlineService } from "@/api/commands/netease";
+import {
+  checkOnlineServiceStatus,
+  ensureOnlineService,
+  restartOnlineService,
+} from "@/api/commands/netease";
 
 type ServiceState = "checking" | "restarting" | "available" | "unavailable";
 
@@ -17,6 +21,7 @@ export const useOnlineServiceStore = defineStore("onlineService", () => {
   const isRestarting = ref(false);
   let timer: number | null = null;
   let started = false;
+  let startPromise: Promise<void> | null = null;
   let failureStreak = 0;
 
   const isAvailable = computed(() => state.value === "available");
@@ -99,11 +104,35 @@ export const useOnlineServiceStore = defineStore("onlineService", () => {
     }
   }
 
+  async function ensureStarted() {
+    let didStart = false;
+    if (!started) {
+      started = true;
+      didStart = true;
+      state.value = "checking";
+      document.addEventListener("visibilitychange", handleVisibilityChange);
+    }
+    if (startPromise) return startPromise;
+    if (isAvailable.value) {
+      if (didStart) scheduleNextCheck();
+      return;
+    }
+
+    startPromise = (async () => {
+      try {
+        await ensureOnlineService();
+      } catch (error) {
+        message.value = error instanceof Error ? error.message : String(error);
+      }
+      await checkNow();
+    })().finally(() => {
+      startPromise = null;
+    });
+    return startPromise;
+  }
+
   function start() {
-    if (started) return;
-    started = true;
-    document.addEventListener("visibilitychange", handleVisibilityChange);
-    void checkNow();
+    void ensureStarted();
   }
 
   function stop() {
@@ -121,6 +150,7 @@ export const useOnlineServiceStore = defineStore("onlineService", () => {
     isRestarting,
     isAvailable,
     checkNow,
+    ensureStarted,
     restartService,
     start,
     stop,

--- a/src/stores/playerStore.ts
+++ b/src/stores/playerStore.ts
@@ -2,8 +2,13 @@ import { ref, computed } from "vue";
 import { defineStore } from "pinia";
 import { ElMessage } from "element-plus";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
-import type { MusicFile, SongInfo } from "@/types/model";
-import { PlayMode, ViewMode } from "@/types/model";
+import type {
+  MusicFile,
+  PlaybackPhase,
+  PlaybackQueueItem,
+  SongInfo,
+} from "@/types/model";
+import { PlayMode } from "@/types/model";
 import { i18n } from "@/i18n";
 import { joinPathSegment } from "@/utils/pathUtils";
 import { getLocalMusicDisplayInfo } from "@/utils/songUtils";
@@ -12,6 +17,7 @@ import {
   handleEvent,
   playNeteaseSong,
   playTrack,
+  preparePlaybackRequest,
   prefetchNeteaseSong,
   getPlaybackState,
   seekTo,
@@ -21,7 +27,7 @@ import { usePlaybackQueue, type PlayOnlineOptions } from "@/composables/usePlayb
 import { usePlaybackVolume } from "@/composables/usePlaybackVolume";
 import { useViewStore } from "./viewStore";
 import { useLocalMusicStore } from "./localMusicStore";
-import { useOnlineMusicStore } from "./onlineMusicStore";
+import { useOnlineServiceStore } from "./onlineServiceStore";
 import { usePlaylistStore } from "./playlistStore";
 
 function debugPlaybackLog(message: string) {
@@ -41,6 +47,7 @@ interface PlaybackEndedPayload {
 interface PlaybackSnapshot {
   music: MusicFile | null;
   onlineSong: SongInfo | null;
+  localQueue: MusicFile[];
   onlineQueue: SongInfo[];
   playlistId: string | null;
   isPlaying: boolean;
@@ -49,12 +56,17 @@ interface PlaybackSnapshot {
   backendTrackId: number;
 }
 
+interface PlayLocalOptions {
+  fromPlaylistId?: string;
+  queue?: MusicFile[];
+}
+
 const MAX_SHUFFLE_HISTORY_SIZE = 200;
 
 export const usePlayerStore = defineStore("player", () => {
   const viewStore = useViewStore();
   const localStore = useLocalMusicStore();
-  const onlineStore = useOnlineMusicStore();
+  const onlineServiceStore = useOnlineServiceStore();
   const playlistStore = usePlaylistStore();
 
   const playMode = ref<PlayMode>(PlayMode.SEQUENTIAL);
@@ -63,6 +75,7 @@ export const usePlayerStore = defineStore("player", () => {
   const currentOnlineSong = ref<SongInfo | null>(null);
   const isPlaying = ref(false);
   const isLoadingSong = ref(false);
+  const playbackPhase = ref<PlaybackPhase>("idle");
   const currentPlayTime = ref(0);
   const currentTrackDurationMs = ref(0);
   const currentBackendTrackId = ref(0);
@@ -73,6 +86,8 @@ export const usePlayerStore = defineStore("player", () => {
   let shuffleContextKey = "";
   let shuffleHistory: string[] = [];
   let shuffleCursor = -1;
+  let playbackRequestId = 0;
+  let fallbackPlaybackSnapshot: PlaybackSnapshot | null = null;
   /** 当前从播放列表播放时记录列表 id，用于上一曲/下一曲 */
   const currentPlaylistId = ref<string | null>(null);
 
@@ -83,8 +98,6 @@ export const usePlayerStore = defineStore("player", () => {
 
   const playbackQueue = usePlaybackQueue({
     getPlayMode: () => playMode.value,
-    getViewMode: () => viewStore.viewMode,
-    getFallbackOnlineQueue: () => onlineStore.onlineSongs,
     getCurrentPlaylistId: () => currentPlaylistId.value,
     setCurrentPlaylistId: (id) => {
       currentPlaylistId.value = id;
@@ -92,6 +105,7 @@ export const usePlayerStore = defineStore("player", () => {
     getPlaylist: playlistStore.getPlaylist,
     prefetchOnlineSong: prefetchNeteaseSong,
   });
+  const currentLocalQueue = ref<MusicFile[]>([]);
   const currentOnlineQueue = playbackQueue.currentOnlineQueue;
 
   const hasCurrentTrack = computed(
@@ -130,6 +144,76 @@ export const usePlayerStore = defineStore("player", () => {
     return null;
   });
 
+  const playbackQueueItems = computed<PlaybackQueueItem[]>(() => {
+    if (currentPlaylistId.value) {
+      const playlist = playlistStore.getPlaylist(currentPlaylistId.value);
+      return (playlist?.items ?? []).map((item, sourceIndex) => {
+        if (item.type === "online") {
+          return {
+            key: `online:${sourceIndex}:${item.song.id}`,
+            title: item.song.name,
+            artist: item.song.artists.join(", "),
+            source: "online",
+            sourceIndex,
+            isCurrent: currentOnlineSong.value?.id === item.song.id,
+          };
+        }
+        const file = localMusicByFileName.value.get(item.file_name);
+        const display = getLocalMusicDisplayInfo(
+          file ?? { id: -1, file_name: item.file_name },
+          i18n.global.t("common.unknownArtist")
+        );
+        return {
+          key: `local:${sourceIndex}:${item.file_name}`,
+          title: display.title,
+          artist: display.artist,
+          source: "local",
+          sourceIndex,
+          isCurrent: currentMusic.value?.file_name === item.file_name,
+          disabled: !file,
+        };
+      });
+    }
+
+    if (currentMusic.value) {
+      const queue = currentLocalQueue.value.length
+        ? currentLocalQueue.value
+        : localStore.musicFiles;
+      return queue.map((file, sourceIndex) => {
+        const display = getLocalMusicDisplayInfo(
+          file,
+          i18n.global.t("common.unknownArtist")
+        );
+        return {
+          key: `local:${getLocalTrackKey(file)}`,
+          title: display.title,
+          artist: display.artist,
+          source: "local",
+          sourceIndex,
+          isCurrent: getLocalTrackKey(file) === getLocalTrackKey(currentMusic.value!),
+        };
+      });
+    }
+
+    return currentOnlineQueue.value.map((song, sourceIndex) => ({
+      key: `online:${song.id}`,
+      title: song.name,
+      artist: song.artists.join(", "),
+      source: "online",
+      sourceIndex,
+      isCurrent: currentOnlineSong.value?.id === song.id,
+    }));
+  });
+
+  const playbackQueueTitle = computed(() => {
+    if (currentPlaylistId.value) {
+      return playlistStore.getPlaylist(currentPlaylistId.value)?.name ?? "";
+    }
+    return currentMusic.value
+      ? i18n.global.t("common.localMusic")
+      : i18n.global.t("onlineMusic.title");
+  });
+
   function clampPlayTime(positionMs: number): number {
     const duration = currentTrackDuration.value;
     const safePosition = Math.max(0, positionMs || 0);
@@ -146,6 +230,7 @@ export const usePlayerStore = defineStore("player", () => {
     return {
       music: currentMusic.value,
       onlineSong: currentOnlineSong.value,
+      localQueue: [...currentLocalQueue.value],
       onlineQueue: [...currentOnlineQueue.value],
       playlistId: currentPlaylistId.value,
       isPlaying: isPlaying.value,
@@ -158,16 +243,54 @@ export const usePlayerStore = defineStore("player", () => {
   function restorePlaybackSnapshot(snapshot: PlaybackSnapshot) {
     currentMusic.value = snapshot.music;
     currentOnlineSong.value = snapshot.onlineSong;
+    currentLocalQueue.value = snapshot.localQueue;
     currentOnlineQueue.value = snapshot.onlineQueue;
     currentPlaylistId.value = snapshot.playlistId;
     currentPlayTime.value = snapshot.positionMs;
     currentTrackDurationMs.value = snapshot.durationMs;
     currentBackendTrackId.value = snapshot.backendTrackId;
     isPlaying.value = snapshot.isPlaying;
+    isLoadingSong.value = false;
+    playbackPhase.value = "idle";
     if (snapshot.isPlaying && (snapshot.music || snapshot.onlineSong)) {
       startPlayTimeTracking();
     } else {
       stopPlayTimeTracking();
+    }
+  }
+
+  function beginPlaybackRequest(): number {
+    if (!isLoadingSong.value || fallbackPlaybackSnapshot === null) {
+      fallbackPlaybackSnapshot = capturePlaybackSnapshot();
+    }
+    const requestId = ++playbackRequestId;
+    isLoadingSong.value = true;
+    isPlaying.value = false;
+    stopPlayTimeTracking();
+    resetProgressState();
+    return requestId;
+  }
+
+  function isCurrentPlaybackRequest(requestId: number): boolean {
+    return requestId === playbackRequestId;
+  }
+
+  function completePlaybackRequest(requestId: number): boolean {
+    if (!isCurrentPlaybackRequest(requestId)) return false;
+    isLoadingSong.value = false;
+    playbackPhase.value = "idle";
+    fallbackPlaybackSnapshot = null;
+    return true;
+  }
+
+  function failPlaybackRequest(requestId: number) {
+    if (!isCurrentPlaybackRequest(requestId)) return;
+    const snapshot = fallbackPlaybackSnapshot;
+    fallbackPlaybackSnapshot = null;
+    if (snapshot) restorePlaybackSnapshot(snapshot);
+    else {
+      isLoadingSong.value = false;
+      playbackPhase.value = "idle";
     }
   }
 
@@ -274,70 +397,77 @@ export const usePlayerStore = defineStore("player", () => {
     playbackClock.stop();
   }
 
-  async function playMusic(music: MusicFile, options?: { fromPlaylistId?: string }) {
-    const previousPlayback = capturePlaybackSnapshot();
+  async function playMusic(music: MusicFile, options?: PlayLocalOptions) {
+    const requestId = beginPlaybackRequest();
     try {
-      if (!options?.fromPlaylistId) currentPlaylistId.value = null;
+      if (options?.fromPlaylistId) {
+        currentPlaylistId.value = options.fromPlaylistId;
+        currentLocalQueue.value = [];
+      } else {
+        currentPlaylistId.value = null;
+        const nextQueue = options?.queue ?? currentLocalQueue.value;
+        currentLocalQueue.value = nextQueue.some(
+          (item) => getLocalTrackKey(item) === getLocalTrackKey(music)
+        )
+          ? [...nextQueue]
+          : [...localStore.musicFiles];
+      }
       playbackQueue.clearOnlineQueue();
       debugPlaybackLog(`[播放控制] 开始播放本地音乐: ${music.file_name}`);
 
-      isLoadingSong.value = true;
-      isPlaying.value = false;
-      stopPlayTimeTracking();
-      resetProgressState();
-
       currentMusic.value = music;
       currentOnlineSong.value = null;
+      playbackPhase.value = "buffering";
+      await preparePlaybackRequest(requestId);
+      if (!isCurrentPlaybackRequest(requestId)) return;
 
       const fullPath = joinPathSegment(localStore.currentDirectory, music.file_name);
-      const playResult = await playTrack({ type: "local", path: fullPath });
+      const playResult = await playTrack({ type: "local", path: fullPath }, requestId);
+      if (!isCurrentPlaybackRequest(requestId)) return;
       currentBackendTrackId.value = playResult.track_id;
       updateProgressFromBackend(playResult);
 
-      isLoadingSong.value = false;
+      if (!completePlaybackRequest(requestId)) return;
       isPlaying.value = true;
       startPlayTimeTracking();
 
-      if (options?.fromPlaylistId) currentPlaylistId.value = options.fromPlaylistId;
       debugPlaybackLog(`[播放控制] 本地音乐播放成功: ${music.file_name}`);
     } catch (error) {
+      if (!isCurrentPlaybackRequest(requestId)) return;
       console.error("[播放控制] 播放本地音乐失败:", error);
       ElMessage.error(`${i18n.global.t("errors.playFailed")}: ${error}`);
-      isLoadingSong.value = false;
-      restorePlaybackSnapshot(previousPlayback);
+      failPlaybackRequest(requestId);
     }
   }
 
   async function playOnlineSong(song: SongInfo, options?: PlayOnlineOptions) {
-    const previousPlayback = capturePlaybackSnapshot();
+    if (
+      currentOnlineSong.value?.id === song.id &&
+      isPlaying.value &&
+      !isLoadingSong.value
+    ) {
+      playbackQueue.applyOnlinePlaybackContext(song, options);
+      void playbackQueue.prefetchNextOnlineSong(song);
+      debugPlaybackLog("[播放控制] 歌曲正在播放，忽略重复请求");
+      return;
+    }
+
+    const requestId = beginPlaybackRequest();
     try {
-      if (
-        currentOnlineSong.value?.id === song.id &&
-        isPlaying.value &&
-        !isLoadingSong.value
-      ) {
-        playbackQueue.applyOnlinePlaybackContext(options);
-        void playbackQueue.prefetchNextOnlineSong(song);
-        debugPlaybackLog("[播放控制] 歌曲正在播放，忽略重复请求");
-        return;
-      }
-      if (isLoadingSong.value) {
-        debugPlaybackLog("[播放控制] 歌曲正在加载中，忽略重复请求");
-        return;
-      }
-      playbackQueue.applyOnlinePlaybackContext(options);
+      playbackQueue.applyOnlinePlaybackContext(song, options);
 
       debugPlaybackLog(
         `[播放控制] 开始播放在线歌曲: ${song.name} - ${song.artists.join(", ")}`
       );
 
-      isLoadingSong.value = true;
-      isPlaying.value = false;
-      stopPlayTimeTracking();
-      resetProgressState();
-
       currentOnlineSong.value = song;
       currentMusic.value = null;
+      currentLocalQueue.value = [];
+      playbackPhase.value = "resolving";
+      await preparePlaybackRequest(requestId);
+      if (!isCurrentPlaybackRequest(requestId)) return;
+      await onlineServiceStore.ensureStarted();
+      if (!isCurrentPlaybackRequest(requestId)) return;
 
       const playResult = await playNeteaseSong({
         id: song.id,
@@ -345,32 +475,36 @@ export const usePlayerStore = defineStore("player", () => {
         artist: song.artists.join(", "),
         picUrl: song.pic_url || undefined,
       });
+      if (!isCurrentPlaybackRequest(requestId)) return;
 
       debugPlaybackLog("[播放控制] 获取到播放URL，准备播放");
-      const startResult = await playTrack({
-        type: "online",
-        url: playResult.url,
-        cache_key: song.id,
-      });
+      playbackPhase.value = "buffering";
+      const startResult = await playTrack(
+        {
+          type: "online",
+          url: playResult.url,
+          cache_key: song.id,
+        },
+        requestId
+      );
+      if (!isCurrentPlaybackRequest(requestId)) return;
       currentBackendTrackId.value = startResult.track_id;
       updateProgressFromBackend(startResult);
 
-      isLoadingSong.value = false;
+      if (!completePlaybackRequest(requestId)) return;
       isPlaying.value = true;
       startPlayTimeTracking();
 
       if (playResult.pic_url && currentOnlineSong.value) {
         currentOnlineSong.value.pic_url = playResult.pic_url;
       }
-      if (options?.fromPlaylistId) currentPlaylistId.value = options.fromPlaylistId;
-
       debugPlaybackLog(`[播放控制] 在线歌曲播放成功: ${song.name}`);
       void playbackQueue.prefetchNextOnlineSong(song);
     } catch (error) {
+      if (!isCurrentPlaybackRequest(requestId)) return;
       console.error("[播放控制] 播放在线歌曲失败:", error);
       ElMessage.error(`${i18n.global.t("errors.playFailedOnline")}: ${error}`);
-      isLoadingSong.value = false;
-      restorePlaybackSnapshot(previousPlayback);
+      failPlaybackRequest(requestId);
     }
   }
 
@@ -385,6 +519,24 @@ export const usePlayerStore = defineStore("player", () => {
     } else {
       await playOnlineSong(item.song, { fromPlaylistId: playlistId });
     }
+  }
+
+  async function playQueueItem(index: number) {
+    if (currentPlaylistId.value) {
+      await playFromPlaylist(currentPlaylistId.value, index);
+      return;
+    }
+    if (currentMusic.value) {
+      const queue = currentLocalQueue.value.length
+        ? currentLocalQueue.value
+        : localStore.musicFiles;
+      const music = queue[index];
+      if (music) await playMusic(music, { queue });
+      return;
+    }
+    const queue = currentOnlineQueue.value;
+    const song = queue[index];
+    if (song) await playOnlineSong(song, { queue });
   }
 
   async function togglePlay() {
@@ -467,12 +619,16 @@ export const usePlayerStore = defineStore("player", () => {
     }
 
     if (currentMusic.value) {
+      const queue =
+        currentLocalQueue.value.length > 0
+          ? currentLocalQueue.value
+          : localStore.musicFiles;
       return {
         contextKey: `local:${localStore.currentDirectory ?? "default"}`,
         currentKey: getLocalTrackKey(currentMusic.value),
-        targets: localStore.musicFiles.map((music) => ({
+        targets: queue.map((music) => ({
           key: getLocalTrackKey(music),
-          play: () => playMusic(music),
+          play: () => playMusic(music, { queue }),
         })),
       };
     }
@@ -537,11 +693,6 @@ export const usePlayerStore = defineStore("player", () => {
 
   async function playNextOrPreviousMusic(step: number) {
     try {
-      if (isLoadingSong.value) {
-        debugPlaybackLog("[播放控制] 歌曲正在加载中，忽略切换请求");
-        return;
-      }
-
       if (playMode.value === PlayMode.RANDOM) {
         await playRandomWithHistory(step);
         return;
@@ -573,27 +724,27 @@ export const usePlayerStore = defineStore("player", () => {
         currentPlaylistId.value = null;
       }
 
-      if (viewStore.viewMode === ViewMode.LOCAL) {
-        if (localStore.musicFiles.length === 0) {
+      if (currentMusic.value) {
+        const queue =
+          currentLocalQueue.value.length > 0
+            ? currentLocalQueue.value
+            : localStore.musicFiles;
+        if (queue.length === 0) {
           ElMessage.warning(i18n.global.t("messages.noLocalMusic"));
           return;
         }
 
-        let currentIndex = localStore.musicFiles.findIndex(
+        let currentIndex = queue.findIndex(
           (file) =>
             currentMusic.value !== null &&
             getLocalTrackKey(file) === getLocalTrackKey(currentMusic.value)
         );
         if (currentIndex === -1) currentIndex = 0;
 
-        const nextIndex = getSequentialIndex(
-          currentIndex,
-          step,
-          localStore.musicFiles.length
-        );
+        const nextIndex = getSequentialIndex(currentIndex, step, queue.length);
 
-        await playMusic(localStore.musicFiles[nextIndex]);
-      } else {
+        await playMusic(queue[nextIndex], { queue });
+      } else if (currentOnlineSong.value) {
         const queue = playbackQueue.getActiveOnlineQueue();
         if (queue.length === 0) {
           ElMessage.warning(i18n.global.t("messages.noOnlineMusic"));
@@ -620,9 +771,11 @@ export const usePlayerStore = defineStore("player", () => {
       const list = playlistStore.getPlaylist(currentPlaylistId.value);
       return list?.items.length ?? 0;
     }
-    return viewStore.viewMode === ViewMode.LOCAL
-      ? localStore.musicFiles.length
-      : playbackQueue.getActiveOnlineQueue().length;
+    if (currentMusic.value) {
+      return currentLocalQueue.value.length || localStore.musicFiles.length;
+    }
+    if (currentOnlineSong.value) return playbackQueue.getActiveOnlineQueue().length;
+    return 0;
   }
 
   function getPlayStep(direction: number): number {
@@ -654,7 +807,9 @@ export const usePlayerStore = defineStore("player", () => {
     if (currentMusic.value) {
       await playMusic(
         currentMusic.value,
-        currentPlaylistId.value ? { fromPlaylistId: currentPlaylistId.value } : undefined
+        currentPlaylistId.value
+          ? { fromPlaylistId: currentPlaylistId.value }
+          : { queue: currentLocalQueue.value }
       );
     } else if (currentOnlineSong.value) {
       await playOnlineSong(
@@ -720,14 +875,18 @@ export const usePlayerStore = defineStore("player", () => {
     currentOnlineSong,
     isPlaying,
     isLoadingSong,
+    playbackPhase,
     currentPlayTime,
     volume,
     currentPlaylistId,
+    currentLocalQueue,
     currentOnlineQueue,
 
     hasCurrentTrack,
     currentTrackDuration,
     currentTrackInfo,
+    playbackQueueItems,
+    playbackQueueTitle,
 
     startPlayTimeTracking,
     stopPlayTimeTracking,
@@ -737,6 +896,7 @@ export const usePlayerStore = defineStore("player", () => {
     playOnlineSong,
     prefetchOnlineSong,
     playFromPlaylist,
+    playQueueItem,
     togglePlay,
     adjustVolume,
     syncVolumeToBackend,

--- a/src/stores/viewStore.ts
+++ b/src/stores/viewStore.ts
@@ -5,6 +5,7 @@ import { ViewMode } from "@/types/model";
 export const useViewStore = defineStore("view", () => {
   const viewMode = ref<ViewMode>(ViewMode.LOCAL);
   const showImmersiveMode = ref(false);
+  const showPlaybackQueue = ref(false);
   const playlistSearchKeyword = ref("");
   /** 在线模块内最后访问路径（搜索页 /online 或歌手页 /artist/:id），用于从本地/设置返回时恢复 */
   const lastOnlinePath = ref("/online");
@@ -18,6 +19,7 @@ export const useViewStore = defineStore("view", () => {
   }
 
   function showImmersive() {
+    showPlaybackQueue.value = false;
     showImmersiveMode.value = true;
   }
 
@@ -29,9 +31,18 @@ export const useViewStore = defineStore("view", () => {
     playlistSearchKeyword.value = keyword.trim();
   }
 
+  function togglePlaybackQueue() {
+    showPlaybackQueue.value = !showPlaybackQueue.value;
+  }
+
+  function closePlaybackQueue() {
+    showPlaybackQueue.value = false;
+  }
+
   return {
     viewMode,
     showImmersiveMode,
+    showPlaybackQueue,
     playlistSearchKeyword,
     lastOnlinePath,
     setViewMode,
@@ -39,5 +50,7 @@ export const useViewStore = defineStore("view", () => {
     showImmersive,
     exitImmersive,
     setPlaylistSearchKeyword,
+    togglePlaybackQueue,
+    closePlaybackQueue,
   };
 });

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -85,6 +85,18 @@ export interface PlayStartResult {
   track_id: number;
 }
 
+export type PlaybackPhase = "idle" | "resolving" | "buffering";
+
+export interface PlaybackQueueItem {
+  key: string;
+  title: string;
+  artist: string;
+  source: "local" | "online";
+  sourceIndex: number;
+  isCurrent: boolean;
+  disabled?: boolean;
+}
+
 export interface OnlineServiceStatus {
   available: boolean;
   status_code: number | null;

--- a/src/views/ArtistView.vue
+++ b/src/views/ArtistView.vue
@@ -27,7 +27,6 @@
       :totalCount="artistStore.artistSongsTotal"
       :showTitle="false"
       @play="playArtistSong"
-      @prefetch="playerStore.prefetchOnlineSong"
       @toggle-current="playerStore.togglePlay"
       @download="downloadOnlineSong"
       @load-more="artistStore.loadMoreArtistSongs"

--- a/src/views/LocalMusicView.vue
+++ b/src/views/LocalMusicView.vue
@@ -5,9 +5,10 @@
       :currentMusic="playerStore.currentMusic"
       :isPlaying="playerStore.isPlaying"
       :loading="localStore.isLoading"
+      :refreshing="localStore.isRefreshing"
       :getDefaultDirectory="localStore.getDefaultDirectory"
       :showImportButton="true"
-      @play="playerStore.playMusic"
+      @play="playLocalMusic"
       @toggle-current="playerStore.togglePlay"
       @import="importMusic"
     />
@@ -25,6 +26,7 @@ import { useViewStore } from "@/stores/viewStore";
 import MusicList from "@/components/feature/MusicList/MusicList.vue";
 import { ViewMode } from "@/types/model";
 import { importMusic as importMusicCommand } from "@/api/commands/file";
+import type { MusicFile } from "@/types/model";
 
 const { t } = useI18n();
 const localStore = useLocalMusicStore();
@@ -34,6 +36,10 @@ const viewStore = useViewStore();
 onMounted(() => {
   viewStore.setViewMode(ViewMode.LOCAL);
 });
+
+function playLocalMusic(music: MusicFile) {
+  void playerStore.playMusic(music, { queue: localStore.filteredMusicFiles });
+}
 
 async function importMusic() {
   try {

--- a/src/views/OnlineMusicView.vue
+++ b/src/views/OnlineMusicView.vue
@@ -8,7 +8,6 @@
       :loading="onlineStore.isSearchLoading"
       :totalCount="onlineStore.onlineSongsTotal"
       @play="playOnlineSongFromSearch"
-      @prefetch="playerStore.prefetchOnlineSong"
       @toggle-current="playerStore.togglePlay"
       @download="downloadOnlineSong"
       @load-more="onlineStore.loadMoreResults"

--- a/src/views/PlaylistView.vue
+++ b/src/views/PlaylistView.vue
@@ -120,7 +120,6 @@
         :selected-keys="selectedRowKeys"
         width="reading"
         @activate="playAt($event.sourceIndex)"
-        @intent="prefetchTrack($event.sourceIndex)"
         @toggle-current="playerStore.togglePlay"
         @toggle-select="toggleSelectRow($event.sourceIndex)"
         @visible-items="scheduleVisibleLocalCovers"
@@ -404,11 +403,6 @@ function playAt(index: number) {
   const list = playlist.value;
   if (!list) return;
   playerStore.playFromPlaylist(list.id, index);
-}
-
-function prefetchTrack(index: number) {
-  const song = resolvedItems.value[index]?.songInfo;
-  if (song) void playerStore.prefetchOnlineSong(song);
 }
 
 function playAll() {


### PR DESCRIPTION
## Summary

- make playback requests replaceable and add progressive online buffering with stable queue context
- start the online sidecar on demand and limit prefetching to the next track
- restore the local library from cache immediately, then refresh it with incremental directory scanning
- add a playback queue drawer and refine player, list, settings, accessibility, and compact-window behavior
- fix immersive background updates during rapid track changes
- bump the application version to 1.3.2

## Validation

- npm run typecheck
- npm run test:run (17 passed)
- npm run build
- cargo fmt --check
- cargo clippy --all-targets -- -D warnings
- cargo test (18 passed)