### PR TITLE
release: v1.3.4 improve online service reliability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rmusic",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rmusic",
-      "version": "1.3.3",
+      "version": "1.3.4",
       "dependencies": {
         "@element-plus/icons-vue": "^2.3.1",
         "@tauri-apps/api": "^2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rmusic",
   "private": true,
-  "version": "1.3.3",
+  "version": "1.3.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3734,7 +3734,7 @@ dependencies = [
 
 [[package]]
 name = "rmusic"
-version = "1.3.3"
+version = "1.3.4"
 dependencies = [
  "hmac",
  "rand 0.8.5",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rmusic"
-version = "1.3.3"
+version = "1.3.4"
 description = "A modern, lightweight cross-platform desktop music player built with Tauri 2 and Vue 3. Play local audio files and stream online music through third-party API proxies."
 authors = ["xudong7"]
 edition = "2021"

--- a/src-tauri/src/netease.rs
+++ b/src-tauri/src/netease.rs
@@ -68,12 +68,16 @@ const USER_AGENT: &str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/
 const HTTP_CONNECT_TIMEOUT: Duration = Duration::from_secs(8);
 const HTTP_RESPONSE_HEADERS_TIMEOUT: Duration = Duration::from_secs(15);
 const JSON_RESPONSE_BODY_TIMEOUT: Duration = Duration::from_secs(15);
+const TRANSIENT_REQUEST_RETRY_DELAYS: [Duration; 2] =
+    [Duration::from_millis(250), Duration::from_millis(700)];
 
 static DEFAULT_CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
 
 fn build_client() -> Result<reqwest::Client, String> {
     reqwest::Client::builder()
         .user_agent(USER_AGENT)
+        // 这里的所有请求都发往内置 localhost 服务，不应被系统代理接管。
+        .no_proxy()
         .connect_timeout(HTTP_CONNECT_TIMEOUT)
         .build()
         .map_err(|e| format!("Failed to build HTTP client: {}", e))
@@ -190,17 +194,47 @@ async fn get_response_json(
     client: reqwest::Client,
     url: String,
 ) -> Result<serde_json::Value, String> {
+    let mut attempt = 0usize;
+    loop {
+        let result = get_response_json_once(client.clone(), url.clone()).await;
+        match result {
+            Ok(json) => return Ok(json),
+            Err(error)
+                if attempt < TRANSIENT_REQUEST_RETRY_DELAYS.len()
+                    && is_transient_request_error(&error) =>
+            {
+                let delay = TRANSIENT_REQUEST_RETRY_DELAYS[attempt];
+                attempt += 1;
+                tokio::time::sleep(delay).await;
+            }
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+async fn get_response_json_once(
+    client: reqwest::Client,
+    url: String,
+) -> Result<serde_json::Value, String> {
     let response = get_response(client, url).await?;
     let text = get_text(response).await?;
-    let json: serde_json::Value = serde_json::from_str(&text).map_err(|e| {
+    serde_json::from_str(&text).map_err(|e| {
         let preview = if text.len() > 200 {
             &text[..200]
         } else {
             &text
         };
         format!("Serialize json error: {}, content: {}", e, preview)
-    })?;
-    Ok(json)
+    })
+}
+
+fn is_transient_request_error(error: &str) -> bool {
+    error.starts_with("API request timed out")
+        || (error.starts_with("API request error:") && !error.contains("HTTP "))
+        || error.starts_with("Read response timed out")
+        || error.starts_with("Read text error:")
+        || error == "Empty response"
+        || error.starts_with("Serialize json error:")
 }
 
 /// search online songs by keywords
@@ -383,8 +417,28 @@ pub async fn search_online_mix(
     };
 
     let (songs_res, artists_res) = tokio::join!(songs_fut, artists_fut);
-    let songs_res = songs_res?;
-    let artists = artists_res?;
+    let (songs_res, artists) = match (songs_res, artists_res) {
+        (Ok(songs), Ok(artists)) => (songs, artists),
+        (Ok(songs), Err(error)) => {
+            eprintln!("Artist search unavailable, returning song results: {error}");
+            (songs, Vec::new())
+        }
+        (Err(error), Ok(artists)) => {
+            eprintln!("Song search unavailable, returning artist results: {error}");
+            (
+                SearchResult {
+                    songs: Vec::new(),
+                    total: 0,
+                },
+                artists,
+            )
+        }
+        (Err(song_error), Err(artist_error)) => {
+            return Err(format!(
+                "Song and artist search failed: songs: {song_error}; artists: {artist_error}"
+            ));
+        }
+    };
 
     Ok(SearchMixResult {
         artists,

--- a/src-tauri/src/service.rs
+++ b/src-tauri/src/service.rs
@@ -31,13 +31,50 @@ pub fn sidecar_name_for_current_platform() -> &'static str {
 
 /// set up the service for the sidecar
 #[tauri::command]
-pub fn ensure_online_service(
+pub async fn ensure_online_service(
     app_handle: tauri::AppHandle,
     process: tauri::State<'_, OnlineServiceProcess>,
 ) -> Result<(), String> {
     let service_name = sidecar_name_for_current_platform();
     let window = app_handle.get_webview_window("main");
-    spawn_service(&app_handle, service_name, window, process.inner())
+    spawn_service(&app_handle, service_name, window, process.inner())?;
+    wait_until_service_ready().await
+}
+
+/// Sidecar 进程创建成功不代表 HTTP 服务已经开始监听。这里用有上限的退避轮询
+/// 建立真正的就绪屏障，避免冷启动期间立即发出的搜索请求撞上未监听端口。
+async fn wait_until_service_ready() -> Result<(), String> {
+    const READY_TIMEOUT: Duration = Duration::from_secs(10);
+    const RETRY_DELAYS: [Duration; 5] = [
+        Duration::from_millis(120),
+        Duration::from_millis(200),
+        Duration::from_millis(350),
+        Duration::from_millis(500),
+        Duration::from_millis(700),
+    ];
+
+    let wait = async {
+        let mut attempt = 0usize;
+        loop {
+            let status = crate::netease::check_online_service_status().await?;
+            if status.available {
+                return Ok(());
+            }
+
+            let delay = RETRY_DELAYS[attempt.min(RETRY_DELAYS.len() - 1)];
+            attempt += 1;
+            tokio::time::sleep(delay).await;
+        }
+    };
+
+    tokio::time::timeout(READY_TIMEOUT, wait)
+        .await
+        .map_err(|_| {
+            format!(
+                "Online service did not become ready within {}s",
+                READY_TIMEOUT.as_secs()
+            )
+        })?
 }
 
 fn spawn_service(
@@ -108,11 +145,10 @@ pub async fn restart_online_service(
 ) -> Result<(), String> {
     let service_name = sidecar_name_for_current_platform();
     shutdown_service(process.inner())?;
-    tokio::time::sleep(Duration::from_millis(500)).await;
+    tokio::time::sleep(Duration::from_millis(300)).await;
     let window = app_handle.get_webview_window("main");
     spawn_service(&app_handle, service_name, window, process.inner())?;
-    tokio::time::sleep(Duration::from_millis(800)).await;
-    Ok(())
+    wait_until_service_ready().await
 }
 
 /// shutdown the service for the sidecar

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "rmusic",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "identifier": "com.rmusic.app",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/App.vue
+++ b/src/App.vue
@@ -11,7 +11,7 @@ import { useRoute, useRouter } from "vue-router";
 import { useI18n } from "vue-i18n";
 import zhCn from "element-plus/es/locale/lang/zh-cn";
 import en from "element-plus/es/locale/lang/en";
-import { ElConfigProvider } from "element-plus";
+import { ElConfigProvider, ElMessage } from "element-plus";
 import HeaderBar from "./components/layout/HeaderBar/HeaderBar.vue";
 import Sidebar from "./components/layout/Sidebar/Sidebar.vue";
 import PlayerBar from "./components/feature/PlayerBar/PlayerBar.vue";
@@ -31,7 +31,7 @@ import { usePlayerStore } from "./stores/playerStore";
 import { usePlaylistStore } from "./stores/playlistStore";
 import { quitApp } from "./api/commands/system";
 
-const { locale } = useI18n();
+const { locale, t } = useI18n();
 const elementLocale = computed(() => (locale.value === "zh" ? zhCn : en));
 const elementMessageConfig = {
   offset: 72,
@@ -96,8 +96,14 @@ async function handleSearch(keyword: string, scope: SearchScope) {
   }
 
   if (kw) {
-    await onlineServiceStore.ensureStarted();
-    await onlineStore.searchOnlineMusic(kw);
+    try {
+      await onlineServiceStore.ensureStarted();
+      await onlineStore.searchOnlineMusic(kw);
+    } catch (error) {
+      console.error("Online service unavailable before search:", error);
+      const detail = error instanceof Error ? error.message : String(error);
+      ElMessage.error(`${t("onlineService.unavailable")}: ${detail}`);
+    }
   } else {
     onlineStore.resetResults();
   }

--- a/src/components/feature/SettingsWindow/SettingsWindow.vue
+++ b/src/components/feature/SettingsWindow/SettingsWindow.vue
@@ -54,8 +54,12 @@ watch(
 );
 
 async function refreshOnlineService() {
-  await onlineServiceStore.ensureStarted();
-  await onlineServiceStore.checkNow();
+  try {
+    await onlineServiceStore.ensureStarted();
+    await onlineServiceStore.checkNow();
+  } catch (error) {
+    console.error("Failed to refresh online service:", error);
+  }
 }
 
 const localeOptions: { value: LocaleKey; labelKey: string }[] = [

--- a/src/stores/onlineMusicStore.ts
+++ b/src/stores/onlineMusicStore.ts
@@ -18,14 +18,6 @@ export const useOnlineMusicStore = defineStore("onlineMusic", () => {
   async function searchOnlineMusic(keyword: string, page = 1) {
     const requestId = ++searchRequestId;
     try {
-      if (page === 1) {
-        onlineSongs.value = [];
-        onlineSongsTotal.value = 0;
-        onlineArtists.value = [];
-      }
-
-      searchKeyword.value = keyword;
-      currentPage.value = page;
       isSearchLoading.value = true;
 
       const result = await searchOnlineMix({
@@ -37,6 +29,9 @@ export const useOnlineMusicStore = defineStore("onlineMusic", () => {
 
       if (requestId !== searchRequestId) return;
 
+      searchKeyword.value = keyword;
+      currentPage.value = page;
+
       if (page === 1) {
         onlineSongs.value = result.songs;
         onlineArtists.value = result.artists ?? [];
@@ -46,7 +41,7 @@ export const useOnlineMusicStore = defineStore("onlineMusic", () => {
 
       onlineSongsTotal.value = result.total;
 
-      if (result.songs.length === 0 && page === 1) {
+      if (result.songs.length === 0 && result.artists.length === 0 && page === 1) {
         ElMessage.info(i18n.global.t("messages.noSearchResult"));
       }
     } catch (error) {

--- a/src/stores/onlineServiceStore.ts
+++ b/src/stores/onlineServiceStore.ts
@@ -22,6 +22,8 @@ export const useOnlineServiceStore = defineStore("onlineService", () => {
   let timer: number | null = null;
   let started = false;
   let startPromise: Promise<void> | null = null;
+  let checkPromise: Promise<boolean> | null = null;
+  let restartPromise: Promise<void> | null = null;
   let failureStreak = 0;
 
   const isAvailable = computed(() => state.value === "available");
@@ -55,45 +57,64 @@ export const useOnlineServiceStore = defineStore("onlineService", () => {
     }, delay);
   }
 
-  async function checkNow() {
-    if (isChecking.value || isRestarting.value) return;
+  function checkNow(): Promise<boolean> {
+    if (checkPromise) return checkPromise;
+    if (isRestarting.value) return Promise.resolve(false);
+
     clearTimer();
     isChecking.value = true;
     if (!lastCheckedAt.value) state.value = "checking";
-    try {
-      applyStatus(await checkOnlineServiceStatus());
-    } catch (error) {
-      state.value = "unavailable";
-      message.value = error instanceof Error ? error.message : String(error);
-      statusCode.value = null;
-      lastCheckedAt.value = Date.now();
-      failureStreak++;
-    } finally {
-      isChecking.value = false;
-      scheduleNextCheck();
-    }
+
+    checkPromise = (async () => {
+      try {
+        applyStatus(await checkOnlineServiceStatus());
+      } catch (error) {
+        state.value = "unavailable";
+        message.value = error instanceof Error ? error.message : String(error);
+        statusCode.value = null;
+        lastCheckedAt.value = Date.now();
+        failureStreak++;
+      } finally {
+        isChecking.value = false;
+        scheduleNextCheck();
+      }
+      return isAvailable.value;
+    })().finally(() => {
+      checkPromise = null;
+    });
+
+    return checkPromise;
   }
 
-  async function restartService() {
-    if (isChecking.value || isRestarting.value) return;
-    isRestarting.value = true;
-    state.value = "restarting";
-    message.value = "";
-    statusCode.value = null;
-    let shouldRefreshStatus = false;
-    try {
-      await restartOnlineService();
-      shouldRefreshStatus = true;
-    } catch (error) {
-      state.value = "unavailable";
-      message.value = error instanceof Error ? error.message : String(error);
+  function restartService(): Promise<void> {
+    if (restartPromise) return restartPromise;
+
+    restartPromise = (async () => {
+      if (checkPromise) await checkPromise;
+
+      isRestarting.value = true;
+      state.value = "restarting";
+      message.value = "";
       statusCode.value = null;
-      lastCheckedAt.value = Date.now();
-    } finally {
-      isRestarting.value = false;
-      if (shouldRefreshStatus) await checkNow();
-      else scheduleNextCheck();
-    }
+      let shouldRefreshStatus = false;
+      try {
+        await restartOnlineService();
+        shouldRefreshStatus = true;
+      } catch (error) {
+        state.value = "unavailable";
+        message.value = error instanceof Error ? error.message : String(error);
+        statusCode.value = null;
+        lastCheckedAt.value = Date.now();
+      } finally {
+        isRestarting.value = false;
+        if (shouldRefreshStatus) await checkNow();
+        else scheduleNextCheck();
+      }
+    })().finally(() => {
+      restartPromise = null;
+    });
+
+    return restartPromise;
   }
 
   function handleVisibilityChange() {
@@ -113,18 +134,36 @@ export const useOnlineServiceStore = defineStore("onlineService", () => {
       document.addEventListener("visibilitychange", handleVisibilityChange);
     }
     if (startPromise) return startPromise;
+    if (restartPromise) {
+      await restartPromise;
+      if (isAvailable.value) return;
+    }
     if (isAvailable.value) {
       if (didStart) scheduleNextCheck();
       return;
     }
 
+    state.value = "checking";
+    message.value = "";
+    statusCode.value = null;
+
     startPromise = (async () => {
       try {
         await ensureOnlineService();
       } catch (error) {
+        state.value = "unavailable";
         message.value = error instanceof Error ? error.message : String(error);
+        statusCode.value = null;
+        lastCheckedAt.value = Date.now();
+        failureStreak++;
+        scheduleNextCheck();
+        throw error;
       }
-      await checkNow();
+
+      const available = await checkNow();
+      if (!available) {
+        throw new Error(message.value || "Online service is unavailable");
+      }
     })().finally(() => {
       startPromise = null;
     });
@@ -132,7 +171,9 @@ export const useOnlineServiceStore = defineStore("onlineService", () => {
   }
 
   function start() {
-    void ensureStarted();
+    void ensureStarted().catch((error) => {
+      console.error("Failed to start online service:", error);
+    });
   }
 
   function stop() {


### PR DESCRIPTION
## Summary
- wait for the bundled online service to become ready before search or playback
- deduplicate frontend service checks, starts, and restarts
- retry transient local API failures and preserve partial song or artist results
- keep the last successful search result when a new request fails
- bump application version to 1.3.4

## Verification
- `npm run typecheck`
- `npm run test:run` (17 passed)
- `npm run build`
- `cargo test --manifest-path src-tauri/Cargo.toml` (18 passed)
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`
- `git diff --check`